### PR TITLE
[FEAT]: 본인인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.h2database:h2'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // coolsms
+    implementation 'net.nurigo:sdk:4.3.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.meetkey.server.domain.auth.controller;
 
 import com.meetkey.server.domain.auth.service.AuthService;
+import com.meetkey.server.domain.auth.service.SmsService;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.member.enums.Provider;
 import com.meetkey.server.domain.member.repository.MemberRepository;
@@ -13,6 +14,7 @@ import com.meetkey.server.global.security.jwt.JwtUtil;
 import com.meetkey.server.global.security.jwt.dto.JwtResDTO;
 import com.meetkey.server.global.security.oauth.dto.OauthReqDTO;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +29,10 @@ public class AuthController {
     private final JwtUtil jwtUtil;
     private final MemberService memberService;
     private final MemberRepository memberRepository;
+    private final SmsService smsService;
 
     @GetMapping("/test")
-    public ResponseEntity<?> getMember(@AuthenticationPrincipal CustomUserDetails details){
+    public ResponseEntity<?> getMember(@AuthenticationPrincipal CustomUserDetails details) {
         return ResponseEntity.ok()
                 .body(BasicResponse.success(CommonSuccessStatus._OK, memberRepository.findById(1L)));
     }
@@ -69,7 +72,7 @@ public class AuthController {
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> signup(
             @RequestParam("provider") Provider provider,
             @RequestBody OauthReqDTO.SignupReq signupReq
-    ){
+    ) {
         if (provider.equals(Provider.KAKAO)) {
             JwtResDTO.JwtResponse jwts = authService.signup(provider, signupReq);
             return ResponseEntity.ok()
@@ -89,6 +92,30 @@ public class AuthController {
         JwtResDTO.JwtResponse jwts = authService.reissue(refreshToken);
         return ResponseEntity.ok()
                 .body(BasicResponse.success(CommonSuccessStatus._OK, jwts));
+    }
+
+    @Operation(summary = "인증번호 발송 API", description = "phone 해당하는 번호에 인증번호를 발송합니다.")
+    @PostMapping("/sms/send")
+    public ResponseEntity<BasicResponse<Boolean>> sendAuthCode(@RequestParam String phone) {
+        smsService.sendAuthCode(phone);
+
+        return ResponseEntity
+                .ok()
+                .body(BasicResponse.success(CommonSuccessStatus._OK, true));
+    }
+
+    @Operation(summary = "인증번호 검증 API", description = "인증번호가 일치하는지 검증합니다. (인증시간 180초)")
+    @PostMapping("/sms/verify")
+    public ResponseEntity<BasicResponse<Boolean>> verifyAuthCode(
+            @RequestParam String phone,
+            @RequestParam String code
+    ) {
+        smsService.verifyAuthCode(phone, code);
+
+        return ResponseEntity
+                .ok()
+                .body(BasicResponse.success(CommonSuccessStatus._OK, true));
+
     }
 
 }

--- a/src/main/java/com/meetkey/server/domain/auth/exception/AuthErrorStatus.java
+++ b/src/main/java/com/meetkey/server/domain/auth/exception/AuthErrorStatus.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthErrorStatus implements BaseCode {
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4001", "토큰 형식이 잘못되었습니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "토큰이 만료되었습니다.");
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "토큰이 만료되었습니다."),
+    VERIFY_FAILED(HttpStatus.BAD_REQUEST, "AUTH4002", "인증번호가 일치하지 않습니다."),
+    SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "인증번호 발송에 실패했습니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/meetkey/server/domain/auth/service/SmsService.java
+++ b/src/main/java/com/meetkey/server/domain/auth/service/SmsService.java
@@ -1,0 +1,76 @@
+package com.meetkey.server.domain.auth.service;
+
+import com.meetkey.server.domain.auth.exception.AuthErrorStatus;
+import com.meetkey.server.domain.auth.exception.AuthException;
+import com.meetkey.server.global.sms.SmsUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SmsService {
+
+    private final DefaultMessageService messageService;
+    private final SmsUtil smsUtil;
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${coolsms.sender}")
+    private String sender;
+
+    /*
+     * 인증번호 발송 로직
+     */
+    public void sendAuthCode(String phoneNumber) {
+        String authCode = smsUtil.createCode(); // 인증번호 생성
+        String messageText = smsUtil.makeAuthMessage(authCode); // 메세지 포멧팅
+
+        Message message = new Message();
+        message.setFrom(sender);
+        message.setTo(phoneNumber); // 요청한 사람의 번호
+        message.setText(messageText);
+
+        SingleMessageSendingRequest request = new SingleMessageSendingRequest(message);
+
+        try {
+            SingleMessageSentResponse response = messageService.sendOne(request);
+            log.info("[SMS] 인증번호 발송 - to: {}, code: {}, response: {}", phoneNumber, authCode, response);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorStatus.SEND_FAILED);
+
+        }
+
+        // redis에 인증번호 저장
+        String redisKey = "SMS:AUTH:" + phoneNumber;
+        redisTemplate.opsForValue().set(redisKey, authCode, 3, TimeUnit.MINUTES); // 3분 유효
+        log.info("[SMS] 인증번호 Redis 저장 - key: {}, code: {}", redisKey, authCode);
+
+    }
+
+    /*
+     * 인증번호 검증 로직
+     */
+    public boolean verifyAuthCode(String phone, String inputCode) {
+
+        String redisKey = "SMS:AUTH:" + phone;
+        String storedCode = redisTemplate.opsForValue().get(redisKey); // 인증기한 180초
+        log.info("[SMS] 인증번호 검증 요청 - key: {}, 입력값: {}, 저장값: {}", redisKey, inputCode, storedCode);
+
+        if (storedCode != null && storedCode.equals(inputCode)) {
+            redisTemplate.delete(redisKey);
+            log.info("[SMS] 인증번호 검증 성공 - key: {}", redisKey);
+            return true;
+        } else {
+            throw new AuthException(AuthErrorStatus.VERIFY_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/meetkey/server/global/config/SmsConfig.java
+++ b/src/main/java/com/meetkey/server/global/config/SmsConfig.java
@@ -1,0 +1,22 @@
+package com.meetkey.server.global.config;
+
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SmsConfig {
+
+    @Value("${coolsms.api-key}")
+    private String apiKey;
+
+    @Value("${coolsms.api-secret}")
+    private String apiSecret;
+
+    @Bean
+    public DefaultMessageService messageService() {
+        return new DefaultMessageService(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+}

--- a/src/main/java/com/meetkey/server/global/sms/SmsUtil.java
+++ b/src/main/java/com/meetkey/server/global/sms/SmsUtil.java
@@ -1,0 +1,20 @@
+package com.meetkey.server.global.sms;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class SmsUtil {
+    // 6자리 난수 생성
+    public static String createCode() {
+        Random random = new Random();
+        int code = 10000 + random.nextInt(90000);
+        return String.valueOf(code);
+    }
+
+    //
+    public String makeAuthMessage(String authCode) {
+        return "[MeetKey 인증번호] " + authCode + "\n본인 확인을 위해 인증번호를 입력해주세요.";
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,10 +6,10 @@ spring:
     name: server
 
   datasource:
-    url: ${DB_URL:jdbc:h2:mem:testdb}
+#    url: ${DB_URL:jdbc:h2:mem:testdb}
     username: ${DB_USERNAME:sa}
     password: ${DB_PW:}
-    driver-class-name: ${DB_DRIVER:org.h2.Driver}
+#    driver-class-name: ${DB_DRIVER:org.h2.Driver}
 
   jpa:
     hibernate:
@@ -18,3 +18,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+coolsms:
+  api-key: ${COOLSMS-API_KEY}
+  api-secret: ${COOLSMS-API_SECRET}
+  sender: ${COOLSMS-SENDER}


### PR DESCRIPTION
## 요약
## 연결된 이슈 번호
- close #13 

## 세부 작업 사항
- 인증번호 발송 구현 (유효기간 180초)
- 인증번호 검증 구현
- application.yaml 파일의 h2 DB쪽은 오류때문에 주석처리 해놨습니다.

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
