### PR TITLE
[FIX] 변경된 member 테이블에 맞게 dev 계정 발급 로직 수정

### DIFF
--- a/src/main/java/com/meetkey/server/ServerApplication.java
+++ b/src/main/java/com/meetkey/server/ServerApplication.java
@@ -3,8 +3,10 @@ package com.meetkey.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableFeignClients
+@EnableJpaAuditing
 @SpringBootApplication
 public class ServerApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/meetkey/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/meetkey/server/domain/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -44,11 +45,12 @@ public class AuthService {
 
     @Transactional
     public JwtResDTO.JwtResponse devSignup(OauthReqDTO.SignupReq req){
-        String providerId = "000000000";
+        String providerId = UUID.randomUUID().toString();
         Provider provider = Provider.KAKAO;
+        String name = "dev_" + UUID.randomUUID().toString();
 
         MemberReqDTO.Signup memberReqDTO = OauthConverter.toMemberSignUpDTO(req);
-        Member member = memberService.devSignup(provider, providerId, memberReqDTO);
+        Member member = memberService.devSignup(provider, providerId, memberReqDTO, name);
 
         return getDevJwtResponseDTO(member);
     }

--- a/src/main/java/com/meetkey/server/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/member/dto/MemberReqDTO.java
@@ -2,6 +2,7 @@ package com.meetkey.server.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.meetkey.server.domain.member.enums.*;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
@@ -12,18 +13,12 @@ public class MemberReqDTO {
     @Builder
     public record Signup(
             @NotNull @JsonFormat(pattern = "yyyy-MM-dd") LocalDate birthday,
+            @NotNull @NotBlank String name,
             @NotNull Gender gender,
             @NotNull HomeTown homeTown,
             @NotNull Language firstLanguage,
             @NotNull Language targetLanguage,
             @NotNull Level targetLanguageLevel,
-            @NotNull String phoneNumber,
-
-            @NotNull List<InterestType> interests,
-            @NotNull SocialType socialType,
-            @NotNull MeetingType meetingType,
-            @NotNull ChatType chatType,
-            @NotNull FriendType friendType,
-            @NotNull RelationType relationType
+            @NotNull String phoneNumber
     ){}
 }

--- a/src/main/java/com/meetkey/server/domain/member/entity/Member.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/Member.java
@@ -65,9 +65,11 @@ public class Member extends BaseEntity {
     private String phoneNumber;
 
     @Column(nullable = false)
+    @Builder.Default
     private Integer recommendCount = 0;
 
     @Column(nullable = false)
+    @Builder.Default
     private Integer notRecommendCount = 0;
 
     private String refreshToken;

--- a/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
@@ -23,6 +23,9 @@ public class MemberService {
     @Transactional
     public Member signup(Provider provider, String providerId, MemberReqDTO.Signup req) {
         Member member = Member.builder()
+                .name(req.name())
+                .targetLanguage(req.targetLanguage())
+                .phoneNumber(req.phoneNumber())
                 .gender(req.gender())
                 .birthday(req.birthday())
                 .firstLanguage(req.firstLanguage())
@@ -43,9 +46,12 @@ public class MemberService {
     }
 
     @Transactional
-    public Member devSignup(Provider provider, String providerId, MemberReqDTO.Signup req) {
+    public Member devSignup(Provider provider, String providerId, MemberReqDTO.Signup req, String name) {
         Member member = Member.builder()
                 .gender(req.gender())
+                .name(name)
+                .targetLanguage(req.targetLanguage())
+                .phoneNumber(req.phoneNumber())
                 .birthday(req.birthday())
                 .firstLanguage(req.firstLanguage())
                 .homeTown(req.homeTown())

--- a/src/main/java/com/meetkey/server/global/security/oauth/converter/OauthConverter.java
+++ b/src/main/java/com/meetkey/server/global/security/oauth/converter/OauthConverter.java
@@ -7,18 +7,13 @@ public class OauthConverter {
     public static MemberReqDTO.Signup toMemberSignUpDTO(OauthReqDTO.SignupReq req){
         return MemberReqDTO.Signup.builder()
                 .birthday(req.birthday())
+                .name(req.name())
                 .gender(req.gender())
                 .firstLanguage(req.firstLanguage())
                 .homeTown(req.homeTown())
                 .phoneNumber(req.phoneNumber())
                 .targetLanguage(req.targetLanguage())
                 .targetLanguageLevel(req.targetLanguageLevel())
-                .interests(req.interests())
-                .meetingType(req.meetingType())
-                .relationType(req.relationType())
-                .chatType(req.chatType())
-                .friendType(req.friendType())
-                .socialType(req.socialType())
                 .build();
     }
 }

--- a/src/main/java/com/meetkey/server/global/security/oauth/dto/OauthReqDTO.java
+++ b/src/main/java/com/meetkey/server/global/security/oauth/dto/OauthReqDTO.java
@@ -15,6 +15,7 @@ public class OauthReqDTO {
     public record SignupReq(
             @NotNull String idToken,
 
+            @NotNull String name,
             @NotNull @JsonFormat(pattern = "yyyy-MM-dd") LocalDate birthday,
             @NotNull Gender gender,
             @NotNull HomeTown homeTown,
@@ -22,13 +23,6 @@ public class OauthReqDTO {
             @NotNull Language targetLanguage,
             @NotNull Level targetLanguageLevel,
 
-            @NotNull String phoneNumber,
-
-            @NotNull List<InterestType> interests,
-            @NotNull SocialType socialType,
-            @NotNull MeetingType meetingType,
-            @NotNull ChatType chatType,
-            @NotNull FriendType friendType,
-            @NotNull RelationType relationType
+            @NotNull String phoneNumber
     ){}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,10 +11,10 @@ spring:
     name: server
 
   datasource:
-    url: ${DB_URL:jdbc:h2:mem:testdb}
-    username: ${DB_USERNAME:sa}
+    url: ${DB_URL:}
+    username: ${DB_USERNAME:}
     password: ${DB_PW:}
-#    driver-class-name: ${DB_DRIVER:org.h2.Driver}
+    driver-class-name: ${DB_DRIVER:}
 
   jpa:
     hibernate:
@@ -25,9 +25,9 @@ spring:
         format_sql: true
 
 coolsms:
-  api-key: ${COOLSMS-API_KEY}
-  api-secret: ${COOLSMS-API_SECRET}
-  sender: ${COOLSMS-SENDER}
+  api-key: ${COOLSMS_API_KEY:}
+  api-secret: ${COOLSMS_API_SECRET:}
+  sender: ${COOLSMS_SENDER:}
 
 admin:
   secret: ${ADMIN_SECRET:1234}


### PR DESCRIPTION
## 요약
- 스크린샷 첨부
<img width="537" height="871" alt="image" src="https://github.com/user-attachments/assets/41fc4b91-b5c4-4d23-91a1-607e07cdb7b8" />


<br>
<br>

## 연결된 이슈 번호
- close #26

<br>
<br>

## 세부 작업 사항
- member 테이블의 필드가 수정되어서 dev 계정 발급할 때 그에 맞게 가짜 데이터를 추가하였습니다.

<br>
<br>

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
