### PR TITLE
[FEAT] 뱃지 구현

### DIFF
--- a/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
@@ -30,6 +30,7 @@ public class AuthController {
     private final AuthService authService;
     private final SmsService smsService;
 
+
     @Value("${admin.secret}")
     private String adminSecret;
 
@@ -94,15 +95,17 @@ public class AuthController {
     @Operation(summary = "인증번호 검증 API", description = "인증번호가 일치하는지 검증합니다. (인증시간 180초)")
     @PostMapping("/sms/verify")
     public ResponseEntity<BasicResponse<Boolean>> verifyAuthCode(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam String phone,
             @RequestParam String code
     ) {
-        smsService.verifyAuthCode(phone, code);
+
+        Long memberId = customUserDetails.getMemberId();
+        smsService.completeAuthentication(memberId, phone, code);
 
         return ResponseEntity
                 .ok()
                 .body(BasicResponse.success(CommonSuccessStatus._OK, true));
-
     }
 
 }

--- a/src/main/java/com/meetkey/server/domain/auth/service/SmsService.java
+++ b/src/main/java/com/meetkey/server/domain/auth/service/SmsService.java
@@ -2,6 +2,11 @@ package com.meetkey.server.domain.auth.service;
 
 import com.meetkey.server.domain.auth.exception.AuthErrorStatus;
 import com.meetkey.server.domain.auth.exception.AuthException;
+import com.meetkey.server.domain.badge.service.BadgeService;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.exception.MemberErrorStatus;
+import com.meetkey.server.domain.member.exception.MemberException;
+import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.global.sms.SmsUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,17 +17,24 @@ import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class SmsService {
 
+    private final MemberRepository memberRepository;
+
     private final DefaultMessageService messageService;
+    private final BadgeService badgeService;
+
     private final SmsUtil smsUtil;
     private final StringRedisTemplate redisTemplate;
+
 
     @Value("${coolsms.sender}")
     private String sender;
@@ -73,4 +85,18 @@ public class SmsService {
             throw new AuthException(AuthErrorStatus.VERIFY_FAILED);
         }
     }
+
+    // 검증 및 포인트 지급
+    public void completeAuthentication(Long memberId, String phone, String inputCode) {
+        verifyAuthCode(phone, inputCode);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        member.updateCertificated();
+
+        badgeService.checkAuthentication(member.getId());
+    }
+
+
 }

--- a/src/main/java/com/meetkey/server/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/meetkey/server/domain/badge/controller/BadgeController.java
@@ -1,0 +1,38 @@
+package com.meetkey.server.domain.badge.controller;
+
+import com.meetkey.server.domain.badge.dto.BadgeResDTO;
+import com.meetkey.server.domain.badge.service.BadgeService;
+import com.meetkey.server.global.apiPayload.response.BasicResponse;
+import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
+import com.meetkey.server.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.meetkey.server.domain.badge.dto.BadgeResDTO.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/badges")
+public class BadgeController {
+
+    private final BadgeService badgeService;
+
+    @Operation(summary = "점수 획득 내역 조회 API", description = "내 뱃지 등급, 점수, 점수 획득 내역을 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<BasicResponse<BadgeResponse>> getBadgeDetail(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long memberId = customUserDetails.getMemberId();
+
+        BadgeResponse response = badgeService.getBadgeDetail(memberId);
+
+        return ResponseEntity.ok()
+                .body(BasicResponse.success(CommonSuccessStatus._OK, response));
+    }
+
+}

--- a/src/main/java/com/meetkey/server/domain/badge/converter/BadgeConverter.java
+++ b/src/main/java/com/meetkey/server/domain/badge/converter/BadgeConverter.java
@@ -1,0 +1,36 @@
+package com.meetkey.server.domain.badge.converter;
+
+import com.meetkey.server.domain.badge.dto.BadgeResDTO;
+import com.meetkey.server.domain.badge.entity.Badge;
+import com.meetkey.server.domain.badge.entity.PointHistory;
+import com.meetkey.server.domain.badge.enums.BadgeLevel;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.meetkey.server.domain.badge.dto.BadgeResDTO.*;
+
+@Component
+public class BadgeConverter {
+
+    public BadgeResponse toBadgeResponse(int totalScore, List<PointHistory> histories) {
+
+        BadgeLevel badgeLevel = BadgeLevel.fromScore(totalScore);
+
+        List<HistoryDetail> details = histories.stream()
+                .map(h -> HistoryDetail.builder()
+                        .reason(h.getReasonType().getDescription())
+                        .amount(h.getChangeAmount())
+                        .date(h.getCreatedAt())
+                        .build())
+                .toList();
+
+        return BadgeResponse.builder()
+                .badgeName(badgeLevel.getName())
+                .totalScore(totalScore)
+                .histories(details)
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/meetkey/server/domain/badge/converter/BadgeConverter.java
+++ b/src/main/java/com/meetkey/server/domain/badge/converter/BadgeConverter.java
@@ -1,7 +1,5 @@
 package com.meetkey.server.domain.badge.converter;
 
-import com.meetkey.server.domain.badge.dto.BadgeResDTO;
-import com.meetkey.server.domain.badge.entity.Badge;
 import com.meetkey.server.domain.badge.entity.PointHistory;
 import com.meetkey.server.domain.badge.enums.BadgeLevel;
 import org.springframework.stereotype.Component;
@@ -13,7 +11,8 @@ import static com.meetkey.server.domain.badge.dto.BadgeResDTO.*;
 @Component
 public class BadgeConverter {
 
-    public BadgeResponse toBadgeResponse(int totalScore, List<PointHistory> histories) {
+    // 점수 획득내역 포함
+    public BadgeResponse toBadgeResponseDetail(int totalScore, List<PointHistory> histories) {
 
         BadgeLevel badgeLevel = BadgeLevel.fromScore(totalScore);
 
@@ -31,6 +30,15 @@ public class BadgeConverter {
                 .histories(details)
                 .build();
 
+    }
+
+    // 점수 획득내역 미포함
+    public BadgeResponse toBadgeResponseSummary(int totalScore) {
+        return BadgeResponse.builder()
+                .badgeName(BadgeLevel.fromScore(totalScore).getName())
+                .totalScore(totalScore)
+                .histories(null)
+                .build();
     }
 
 }

--- a/src/main/java/com/meetkey/server/domain/badge/dto/BadgeResDTO.java
+++ b/src/main/java/com/meetkey/server/domain/badge/dto/BadgeResDTO.java
@@ -1,0 +1,24 @@
+package com.meetkey.server.domain.badge.dto;
+
+import com.meetkey.server.domain.badge.entity.PointHistory;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class BadgeResDTO {
+
+    @Builder
+    public record BadgeResponse(
+            String badgeName,
+            int totalScore,
+            List<HistoryDetail> histories
+    ) {}
+
+    @Builder
+    public record HistoryDetail(
+            String reason,
+            int amount,
+            LocalDateTime date
+    ) {}
+}

--- a/src/main/java/com/meetkey/server/domain/badge/entity/Badge.java
+++ b/src/main/java/com/meetkey/server/domain/badge/entity/Badge.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.domain.badge.entity;
 
+import com.meetkey.server.domain.badge.enums.BadgeLevel;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -24,5 +25,7 @@ public class Badge extends BaseEntity {
     private int total_score = 0;
 
     @Column(nullable = false)
-    private String tier; // enum 으로 추후 변경
+    @Enumerated(EnumType.STRING)
+    private BadgeLevel level;
+
 }

--- a/src/main/java/com/meetkey/server/domain/badge/entity/PointHistory.java
+++ b/src/main/java/com/meetkey/server/domain/badge/entity/PointHistory.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.domain.badge.entity;
 
+import com.meetkey.server.domain.badge.enums.ReasonType;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -24,5 +25,6 @@ public class PointHistory extends BaseEntity {
     private int changeAmount;
 
     @Column(nullable = false)
-    private String reasonType; // 추후 enum 변경
+    @Enumerated(EnumType.STRING)
+    private ReasonType reasonType;
 }

--- a/src/main/java/com/meetkey/server/domain/badge/enums/BadgeLevel.java
+++ b/src/main/java/com/meetkey/server/domain/badge/enums/BadgeLevel.java
@@ -1,0 +1,24 @@
+package com.meetkey.server.domain.badge.enums;
+
+import com.meetkey.server.domain.badge.entity.Badge;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BadgeLevel {
+    NONE("없음", 0),
+    BRONZE("브론즈", 70),
+    SILVER("실버", 80),
+    GOLD("골드", 90);
+
+    private final String name;
+    private final int minScore;
+
+    public static BadgeLevel fromScore(int score) {
+        if (score >= GOLD.minScore) return GOLD;
+        if (score >= SILVER.minScore) return SILVER;
+        if (score >= BRONZE.minScore) return BRONZE;
+        return NONE;
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/badge/enums/ReasonType.java
+++ b/src/main/java/com/meetkey/server/domain/badge/enums/ReasonType.java
@@ -1,0 +1,16 @@
+package com.meetkey.server.domain.badge.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReasonType {
+    AUTH("본인 인증", 20),
+    PROFILE("상세 프로필 작성 완료", 15),
+    ACTIVE("활동적인 멤버", 25),
+    POSITIVE("긍정적인 평가", 15);
+
+    private final String description;
+    private final int defaultScore;
+}

--- a/src/main/java/com/meetkey/server/domain/badge/respository/PointHistoryRepository.java
+++ b/src/main/java/com/meetkey/server/domain/badge/respository/PointHistoryRepository.java
@@ -1,6 +1,7 @@
 package com.meetkey.server.domain.badge.respository;
 
 import com.meetkey.server.domain.badge.entity.PointHistory;
+import com.meetkey.server.domain.badge.enums.ReasonType;
 import com.meetkey.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,7 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
     // 총점 계산
     @Query("SELECT coalesce(sum(p.changeAmount), 0) FROM PointHistory p where p.member = :member")
     int calculateTotalScore(@Param("member") Member member);
+
+    // 특정 사유로 이미 점수를 받았는지 확인
+    boolean existsByMemberAndReasonType(Member member, ReasonType reasonType);
 }

--- a/src/main/java/com/meetkey/server/domain/badge/respository/PointHistoryRepository.java
+++ b/src/main/java/com/meetkey/server/domain/badge/respository/PointHistoryRepository.java
@@ -1,0 +1,18 @@
+package com.meetkey.server.domain.badge.respository;
+
+import com.meetkey.server.domain.badge.entity.PointHistory;
+import com.meetkey.server.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+
+    List<PointHistory> findAllByMemberOrderByCreatedAtDesc(Member member);
+
+    // 총점 계산
+    @Query("SELECT coalesce(sum(p.changeAmount), 0) FROM PointHistory p where p.member = :member")
+    int calculateTotalScore(@Param("member") Member member);
+}

--- a/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
@@ -25,16 +25,26 @@ public class BadgeService {
     private final PointHistoryRepository pointHistoryRepository;
     private final BadgeConverter badgeConverter;
 
-    // 뱃지 정보 조회
+    // 뱃지 정보 조회 (내역 포함)
     @Transactional(readOnly = true)
-    public BadgeResponse getBadgeInfo(Long memberId) {
+    public BadgeResponse getBadgeDetail(Long memberId) {
         Member member = getMember(memberId);
 
         int totalScore = pointHistoryRepository.calculateTotalScore(member);
 
         List<PointHistory> histories = pointHistoryRepository.findAllByMemberOrderByCreatedAtDesc(member);
 
-        return badgeConverter.toBadgeResponse(totalScore, histories);
+        return badgeConverter.toBadgeResponseDetail(totalScore, histories);
+    }
+
+    // 뱃지 정보 조회(내역 미포함)
+    @Transactional(readOnly = true)
+    public BadgeResponse getBadgeSummary(Long memberId) {
+        Member member = getMember(memberId);
+
+        int totalScore = pointHistoryRepository.calculateTotalScore(member);
+
+        return badgeConverter.toBadgeResponseSummary(totalScore);
     }
 
     // 점수 부여

--- a/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
@@ -41,13 +41,67 @@ public class BadgeService {
     public void rewardPoints(Long memberId, ReasonType reasonType) {
         Member member = getMember(memberId);
 
-        PointHistory pointHistory = PointHistory.builder()
-                .member(member)
-                .reasonType(reasonType)
-                .changeAmount(reasonType.getDefaultScore())
-                .build();
+        if (pointHistoryRepository.existsByMemberAndReasonType(member, reasonType)) {
+            return;
+        }
 
-        pointHistoryRepository.save(pointHistory);
+        int currentTotalScore = pointHistoryRepository.calculateTotalScore(member);
+
+        // 100점 이상이라면 지급 X
+        if (currentTotalScore >= 100) {
+            return;
+        }
+
+        int pointsToAdd = reasonType.getDefaultScore();
+        int potentialScore = currentTotalScore + pointsToAdd;
+
+        // 더해서 100점 초과라면 일부만 지급
+        if (potentialScore > 100) {
+            pointsToAdd = 100 - currentTotalScore;
+        }
+
+        if (pointsToAdd > 0) {
+            PointHistory pointHistory = PointHistory.builder()
+                    .member(member)
+                    .reasonType(reasonType)
+                    .changeAmount(reasonType.getDefaultScore())
+                    .build();
+            pointHistoryRepository.save(pointHistory);
+        }
+
+    }
+
+    // 본인 인증
+    public void checkAuthentication(Long memberId) {
+        Member member = getMember(memberId);
+
+        if (Boolean.TRUE.equals(member.isVerified())) {
+            rewardPoints(member.getId(), ReasonType.AUTH);
+        }
+    }
+
+    // 프로필 작성
+    public void checkProfileCompletion(Long memberId) {
+        Member member = getMember(memberId);
+
+        boolean isComplete =
+                member.getLocation() != null &&
+                member.getFirstLanguage() != null &&
+                member.getTargetLanguage() != null &&
+                member.getTargetLanguageLevel() != null;
+
+        if (isComplete) {
+            rewardPoints(member.getId(), ReasonType.PROFILE);
+        }
+    }
+
+    // 긍적적인 평가
+    public void checkPositiveEvaluation(Long memberId) {
+        Member member = getMember(memberId);
+
+        if (member.getRecommendCount() >= 10) {
+            rewardPoints(member.getId(), ReasonType.POSITIVE);
+        }
     }
 
 

--- a/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
@@ -1,0 +1,59 @@
+package com.meetkey.server.domain.badge.service;
+
+import com.meetkey.server.domain.badge.converter.BadgeConverter;
+import com.meetkey.server.domain.badge.entity.PointHistory;
+import com.meetkey.server.domain.badge.enums.ReasonType;
+import com.meetkey.server.domain.badge.respository.PointHistoryRepository;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.exception.MemberErrorStatus;
+import com.meetkey.server.domain.member.exception.MemberException;
+import com.meetkey.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.meetkey.server.domain.badge.dto.BadgeResDTO.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BadgeService {
+
+    private final MemberRepository memberRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+    private final BadgeConverter badgeConverter;
+
+    // 뱃지 정보 조회
+    @Transactional(readOnly = true)
+    public BadgeResponse getBadgeInfo(Long memberId) {
+        Member member = getMember(memberId);
+
+        int totalScore = pointHistoryRepository.calculateTotalScore(member);
+
+        List<PointHistory> histories = pointHistoryRepository.findAllByMemberOrderByCreatedAtDesc(member);
+
+        return badgeConverter.toBadgeResponse(totalScore, histories);
+    }
+
+    // 점수 부여
+    public void rewardPoints(Long memberId, ReasonType reasonType) {
+        Member member = getMember(memberId);
+
+        PointHistory pointHistory = PointHistory.builder()
+                .member(member)
+                .reasonType(reasonType)
+                .changeAmount(reasonType.getDefaultScore())
+                .build();
+
+        pointHistoryRepository.save(pointHistory);
+    }
+
+
+    // 사용자 찾기 메소드
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/member/converter/ProfileConverter.java
+++ b/src/main/java/com/meetkey/server/domain/member/converter/ProfileConverter.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.domain.member.converter;
 
+import com.meetkey.server.domain.badge.dto.BadgeResDTO;
 import com.meetkey.server.domain.member.entity.Interest;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.member.entity.Preference;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.meetkey.server.domain.badge.dto.BadgeResDTO.*;
 import static com.meetkey.server.domain.member.dto.ProfileResDTO.*;
 
 @Component
@@ -120,7 +122,8 @@ public class ProfileConverter {
     public MyProfileResponse toProfileResponse(
             Member member,
             List<Interest> interests,
-            Preference personality
+            Preference personality,
+            BadgeResponse badge
     ) {
         List<String> interestNames = interests.stream()
                 .map(interest -> interest.getType().name())
@@ -133,8 +136,9 @@ public class ProfileConverter {
                 .target(member.getTargetLanguage())
                 .age(member.getAge())
                 .profileImage("image")
-                .recommendCount(0)
-                .notRecommendCount(0)
+                .recommendCount(member.getRecommendCount())
+                .notRecommendCount(member.getNotRecommendCount())
+                .badge(badge)
                 .interests(interestNames)
                 .personalities(toPersonalityUpdateResponse(personality))
                 .bio(member.getBio())
@@ -146,7 +150,8 @@ public class ProfileConverter {
             Member member,
             List<Interest> interests,
             Preference personality,
-            String distance
+            String distance,
+            BadgeResponse badge
     ) {
         List<String> interestNames = interests.stream()
                 .map(interest -> interest.getType().name())
@@ -161,8 +166,9 @@ public class ProfileConverter {
                 .profileImage("image")
                 .location(member.getLocation())
                 .distance(distance)
-                .recommendCount(0)
-                .notRecommendCount(0)
+                .recommendCount(member.getRecommendCount())
+                .notRecommendCount(member.getNotRecommendCount())
+
                 .first(member.getFirstLanguage())
                 .target(member.getTargetLanguage())
                 .level(member.getTargetLanguageLevel())

--- a/src/main/java/com/meetkey/server/domain/member/dto/ProfileResDTO.java
+++ b/src/main/java/com/meetkey/server/domain/member/dto/ProfileResDTO.java
@@ -1,9 +1,12 @@
 package com.meetkey.server.domain.member.dto;
 
+import com.meetkey.server.domain.badge.dto.BadgeResDTO;
 import com.meetkey.server.domain.member.enums.*;
 import lombok.Builder;
 
 import java.util.List;
+
+import static com.meetkey.server.domain.badge.dto.BadgeResDTO.*;
 
 public class ProfileResDTO {
 
@@ -75,6 +78,7 @@ public class ProfileResDTO {
             // 평판
             int recommendCount,
             int notRecommendCount,
+            BadgeResponse badge,
 
             // 관심사
             List<String> interests,
@@ -100,6 +104,8 @@ public class ProfileResDTO {
             // 평판
             int recommendCount,
             int notRecommendCount,
+
+            BadgeResponse badge,
 
             Language first,
             Language target,

--- a/src/main/java/com/meetkey/server/domain/member/entity/Member.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/Member.java
@@ -118,4 +118,8 @@ public class Member extends BaseEntity {
         if (this.notRecommendCount > 0) this.notRecommendCount--;
     }
 
+    public void updateCertificated() {
+        this.isVerified = true;
+    }
+
 }

--- a/src/main/java/com/meetkey/server/domain/member/service/ProfileService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/ProfileService.java
@@ -48,14 +48,16 @@ public class ProfileService {
         if (request.latitude() != null && request.longitude() != null) {
             MemberLocation memberLocation = memberLocationRepository.findByMember(member)
                     .orElse(null);
+
             if (memberLocation == null) {
-                MemberLocation.create(member, request.latitude(), request.longitude());
-                memberLocationRepository.save(memberLocation);
+                MemberLocation newMemberLocation = MemberLocation.create(member, request.latitude(), request.longitude());
+                memberLocationRepository.save(newMemberLocation);
             } else {
                 memberLocation.update(request.latitude(), request.longitude());
             }
         }
 
+        badgeService.checkProfileCompletion(memberId);
         return profileConverter.toProfileUpdateResponse(member);
     }
 
@@ -195,6 +197,8 @@ public class ProfileService {
 
             existing.updateType(type);
         }
+
+        badgeService.checkPositiveEvaluation(toId);
     }
 
     // 사용자 찾기 공통 로직

--- a/src/main/java/com/meetkey/server/domain/member/service/ProfileService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/ProfileService.java
@@ -1,5 +1,7 @@
 package com.meetkey.server.domain.member.service;
 
+import com.meetkey.server.domain.badge.dto.BadgeResDTO;
+import com.meetkey.server.domain.badge.service.BadgeService;
 import com.meetkey.server.domain.member.converter.ProfileConverter;
 import com.meetkey.server.domain.member.entity.Interest;
 import com.meetkey.server.domain.member.entity.Member;
@@ -13,12 +15,14 @@ import com.meetkey.server.domain.member.exception.MemberErrorStatus;
 import com.meetkey.server.domain.member.exception.MemberException;
 import com.meetkey.server.domain.member.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.meetkey.server.domain.badge.dto.BadgeResDTO.*;
 import static com.meetkey.server.domain.member.dto.ProfileReqDTO.*;
 import static com.meetkey.server.domain.member.dto.ProfileResDTO.*;
 
@@ -34,6 +38,7 @@ public class ProfileService {
     private final PreferenceRepository preferenceRepository;
     private final MemberLocationRepository memberLocationRepository;
     private final EvaluationRepository evaluationRepository;
+    private final BadgeService badgeService;
 
     public ProfileUpdateResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
         Member member = getMember(memberId);
@@ -92,7 +97,7 @@ public class ProfileService {
     public PersonalityUpdateResponse updatePersonality(Long memberId, PersonalityUpdateRequest request) {
         Member member = getMember(memberId);
 
-        Preference preference = preferenceRepository.findById(member.getId()).orElse(null);
+        Preference preference = getPreference(member);
         if (preference == null) {
              preference = Preference.create(
                     member,
@@ -119,14 +124,16 @@ public class ProfileService {
     public MyProfileResponse getMyProfile(Long memberId) {
         Member member = getMember(memberId);
 
-        Preference preference = preferenceRepository.findById(member.getId()).orElse(null);
+        Preference preference = getPreference(member);
+
+        BadgeResponse badge = badgeService.getBadgeSummary(member.getId());
 
         List<InterestMember> interestMembers = interestMemberRepository.findAllByMember(member);
         List<Interest> interests = interestMembers.stream()
                 .map(InterestMember::getInterest)
                 .toList();
 
-        return profileConverter.toProfileResponse(member, interests, preference);
+        return profileConverter.toProfileResponse(member, interests, preference, badge);
     }
 
     // 다른 사람 프로필 조회
@@ -143,14 +150,17 @@ public class ProfileService {
                 targetLocation.getLatitude(), targetLocation.getLongitude()
         );
 
-        Preference preference = preferenceRepository.findById(target.getId()).orElse(null);
+        Preference preference = getPreference(target);
+        BadgeResponse badge = badgeService.getBadgeSummary(target.getId());
         List<InterestMember> interestMembers = interestMemberRepository.findAllByMember(target);
         List<Interest> interests = interestMembers.stream()
                 .map(InterestMember::getInterest)
                 .toList();
 
-        return profileConverter.toOtherProfileResponse(target, interests, preference, distance);
+        return profileConverter.toOtherProfileResponse(target, interests, preference, distance, badge);
     }
+
+
 
     public void toggleEvaluation(Long fromId, Long toId, EvaluationType type) {
         Member from = getMember(fromId);
@@ -211,5 +221,11 @@ public class ProfileService {
         // 소수점 첫째 자리까지 포맷팅 (예: "2.5km")
         return String.format("%.1fkm", dist);
 
+    }
+
+    // 선호도 찾기 공통 로직
+    @Nullable
+    private Preference getPreference(Member member) {
+        return preferenceRepository.findById(member.getId()).orElse(null);
     }
 }


### PR DESCRIPTION
## 요약
포인트 지급 및 뱃지 기록 조회를 구현했습니다.

미션에 관한 내용이나 점수가 감점되는 요인들은 신고, 차단, 미션쪽이 완벽하게 구현되지 않아서 제외했습니다.

## 연결된 이슈 번호
- close #28 

## 세부 작업 사항
- 본인 인증 시 점수 지급
- 프로필 작성 시 점수 지급
- 10개 이상의 추천시 점수 지급
- SAFE 뱃지 기록 조회 API
## Approve 하기 전에 확인할 것

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
