### PR TITLE
[FEAT] 매칭 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,14 @@ java {
     }
 }
 
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', 'build/generated/querydsl']
+        }
+    }
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -57,6 +65,12 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 ext {

--- a/src/main/java/com/meetkey/server/domain/match/controller/MatchController.java
+++ b/src/main/java/com/meetkey/server/domain/match/controller/MatchController.java
@@ -10,6 +10,7 @@ import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.global.apiPayload.response.BasicResponse;
 import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
 import com.meetkey.server.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +24,7 @@ public class MatchController {
     private final MatchService matchService;
     private final MemberRepository memberRepository;
 
+    @Operation(summary = "사용자 추천 API", description = "사용자를 추천 받습니다.")
     @GetMapping("/recommendations")
     public BasicResponse<MatchListResDTO> getRecommendations(
         @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -34,6 +36,7 @@ public class MatchController {
         return BasicResponse.success(CommonSuccessStatus._OK, matchService.getRecommendations(member, request));
     }
 
+    @Operation(summary = "스와이프 결과 전송", description = "추천된 사용자의 관심 여부를 전송합니다.")
     @PostMapping("/swipe")
     public BasicResponse<SwipeResDTO> swipe(
         @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/meetkey/server/domain/match/controller/MatchController.java
+++ b/src/main/java/com/meetkey/server/domain/match/controller/MatchController.java
@@ -1,0 +1,47 @@
+package com.meetkey.server.domain.match.controller;
+
+import com.meetkey.server.domain.match.dto.MatchListResDTO;
+import com.meetkey.server.domain.match.dto.RecommendationReqDTO;
+import com.meetkey.server.domain.match.dto.SwipeReqDTO;
+import com.meetkey.server.domain.match.dto.SwipeResDTO;
+import com.meetkey.server.domain.match.service.MatchService;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.repository.MemberRepository;
+import com.meetkey.server.global.apiPayload.response.BasicResponse;
+import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
+import com.meetkey.server.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/matches")
+public class MatchController {
+
+    private final MatchService matchService;
+    private final MemberRepository memberRepository;
+
+    @GetMapping("/recommendations")
+    public BasicResponse<MatchListResDTO> getRecommendations(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @ModelAttribute RecommendationReqDTO request
+    ) {
+        Member member = memberRepository.findById(userDetails.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("Invalid User ID"));
+
+        return BasicResponse.success(CommonSuccessStatus._OK, matchService.getRecommendations(member, request));
+    }
+
+    @PostMapping("/swipe")
+    public BasicResponse<SwipeResDTO> swipe(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @RequestBody @Valid SwipeReqDTO request
+    ) {
+        Member member = memberRepository.findById(userDetails.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("Invalid User ID"));
+
+        return BasicResponse.success(CommonSuccessStatus._OK, matchService.swipe(member, request));
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/match/dto/MatchListResDTO.java
+++ b/src/main/java/com/meetkey/server/domain/match/dto/MatchListResDTO.java
@@ -1,0 +1,20 @@
+package com.meetkey.server.domain.match.dto;
+
+import com.meetkey.server.domain.match.enums.MatchType;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MatchListResDTO(
+    List<RecommendationResDTO> recommendations,
+    SwipeInfoDTO swipeInfo,
+    MatchType matchType
+) {
+    @Builder
+    public record SwipeInfoDTO(
+        int remainingCount,
+        int totalCount
+    ) {
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/match/dto/RecommendationReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/match/dto/RecommendationReqDTO.java
@@ -1,0 +1,21 @@
+package com.meetkey.server.domain.match.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RecommendationReqDTO(
+    List<com.meetkey.server.domain.member.enums.InterestType> interests,
+    // 성격 필터는 Preference 제약으로 인해 생략
+    List<com.meetkey.server.domain.member.enums.HomeTown> homeTown,
+    List<com.meetkey.server.domain.member.enums.Language> nativeLanguage,
+    List<com.meetkey.server.domain.member.enums.Language> targetLanguage,
+    List<com.meetkey.server.domain.member.enums.Level> targetLanguageLevel,
+    Integer minAge,
+    Integer maxAge,
+    Double latitude,
+    Double longitude,
+    Double maxDistance // km 단위
+) {
+}

--- a/src/main/java/com/meetkey/server/domain/match/dto/RecommendationReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/match/dto/RecommendationReqDTO.java
@@ -1,17 +1,21 @@
 package com.meetkey.server.domain.match.dto;
 
+import com.meetkey.server.domain.member.enums.HomeTown;
+import com.meetkey.server.domain.member.enums.InterestType;
+import com.meetkey.server.domain.member.enums.Language;
+import com.meetkey.server.domain.member.enums.Level;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record RecommendationReqDTO(
-    List<com.meetkey.server.domain.member.enums.InterestType> interests,
+    List<InterestType> interests,
     // 성격 필터는 Preference 제약으로 인해 생략
-    List<com.meetkey.server.domain.member.enums.HomeTown> homeTown,
-    List<com.meetkey.server.domain.member.enums.Language> nativeLanguage,
-    List<com.meetkey.server.domain.member.enums.Language> targetLanguage,
-    List<com.meetkey.server.domain.member.enums.Level> targetLanguageLevel,
+    List<HomeTown> homeTown,
+    List<Language> nativeLanguage,
+    List<Language> targetLanguage,
+    List<Level> targetLanguageLevel,
     Integer minAge,
     Integer maxAge,
     Double latitude,

--- a/src/main/java/com/meetkey/server/domain/match/dto/RecommendationResDTO.java
+++ b/src/main/java/com/meetkey/server/domain/match/dto/RecommendationResDTO.java
@@ -1,7 +1,6 @@
 package com.meetkey.server.domain.match.dto;
 
-import com.meetkey.server.domain.member.enums.Gender;
-import com.meetkey.server.domain.member.enums.HomeTown;
+import com.meetkey.server.domain.member.enums.*;
 import lombok.Builder;
 
 import java.util.List;
@@ -23,18 +22,18 @@ public record RecommendationResDTO(
 ) {
     @Builder
     public record LanguageDTO(
-        com.meetkey.server.domain.member.enums.Language language,
-        com.meetkey.server.domain.member.enums.Level level
+        Language language,
+        Level level
     ) {
     }
 
     @Builder
     public record PersonalityDTO(
-        com.meetkey.server.domain.member.enums.SocialType socialType,
-        com.meetkey.server.domain.member.enums.MeetingType meetingType,
-        com.meetkey.server.domain.member.enums.ChatType chatType,
-        com.meetkey.server.domain.member.enums.FriendType friendType,
-        com.meetkey.server.domain.member.enums.RelationType relationType
+        SocialType socialType,
+        MeetingType meetingType,
+        ChatType chatType,
+        FriendType friendType,
+        RelationType relationType
     ) {
     }
 }

--- a/src/main/java/com/meetkey/server/domain/match/dto/RecommendationResDTO.java
+++ b/src/main/java/com/meetkey/server/domain/match/dto/RecommendationResDTO.java
@@ -1,0 +1,40 @@
+package com.meetkey.server.domain.match.dto;
+
+import com.meetkey.server.domain.member.enums.Gender;
+import com.meetkey.server.domain.member.enums.HomeTown;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RecommendationResDTO(
+    Long targetMemberId,
+    String nickname,
+    int age,
+    HomeTown hometown,
+    double distance,
+    Gender gender,
+    LanguageDTO nativeLanguage,
+    LanguageDTO targetLanguage,
+    List<String> interests,
+    PersonalityDTO personality,
+    List<String> photoUrls,
+    String introduction
+) {
+    @Builder
+    public record LanguageDTO(
+        com.meetkey.server.domain.member.enums.Language language,
+        com.meetkey.server.domain.member.enums.Level level
+    ) {
+    }
+
+    @Builder
+    public record PersonalityDTO(
+        com.meetkey.server.domain.member.enums.SocialType socialType,
+        com.meetkey.server.domain.member.enums.MeetingType meetingType,
+        com.meetkey.server.domain.member.enums.ChatType chatType,
+        com.meetkey.server.domain.member.enums.FriendType friendType,
+        com.meetkey.server.domain.member.enums.RelationType relationType
+    ) {
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/match/dto/SwipeReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/match/dto/SwipeReqDTO.java
@@ -1,0 +1,12 @@
+package com.meetkey.server.domain.match.dto;
+
+import com.meetkey.server.domain.match.enums.Action;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record SwipeReqDTO(
+    @NotNull Long targetMemberId,
+    @NotNull Action action
+) {
+}

--- a/src/main/java/com/meetkey/server/domain/match/dto/SwipeResDTO.java
+++ b/src/main/java/com/meetkey/server/domain/match/dto/SwipeResDTO.java
@@ -1,0 +1,11 @@
+package com.meetkey.server.domain.match.dto;
+
+import com.meetkey.server.domain.match.enums.Action;
+import lombok.Builder;
+
+@Builder
+public record SwipeResDTO(
+    Long targetMemberId,
+    Action action
+) {
+}

--- a/src/main/java/com/meetkey/server/domain/match/entity/RecommendationQueue.java
+++ b/src/main/java/com/meetkey/server/domain/match/entity/RecommendationQueue.java
@@ -1,4 +1,4 @@
-package com.meetkey.server.domain.recommend.entity;
+package com.meetkey.server.domain.match.entity;
 
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.global.common.BaseEntity;
@@ -29,4 +29,16 @@ public class RecommendationQueue extends BaseEntity {
 
     @Builder.Default
     private Boolean isSwiped = false;
+
+    @Builder.Default
+    private Boolean isRecycled = false;
+
+    public void markSwiped() {
+        this.isSwiped = true;
+    }
+
+    public void recycle() {
+        this.isSwiped = false;
+        this.isRecycled = true;
+    }
 }

--- a/src/main/java/com/meetkey/server/domain/match/enums/Action.java
+++ b/src/main/java/com/meetkey/server/domain/match/enums/Action.java
@@ -1,0 +1,11 @@
+package com.meetkey.server.domain.match.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Action {
+    LIKE,
+    DISLIKE;
+}

--- a/src/main/java/com/meetkey/server/domain/match/enums/MatchType.java
+++ b/src/main/java/com/meetkey/server/domain/match/enums/MatchType.java
@@ -1,0 +1,12 @@
+package com.meetkey.server.domain.match.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MatchType {
+    DAILY_MATCH,
+    RECYCLE,
+    RANDOM;
+}

--- a/src/main/java/com/meetkey/server/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/meetkey/server/domain/match/repository/MatchRepository.java
@@ -1,0 +1,7 @@
+package com.meetkey.server.domain.match.repository;
+
+import com.meetkey.server.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchRepository extends JpaRepository<Member, Long>, MatchRepositoryCustom {
+}

--- a/src/main/java/com/meetkey/server/domain/match/repository/MatchRepositoryCustom.java
+++ b/src/main/java/com/meetkey/server/domain/match/repository/MatchRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.meetkey.server.domain.match.repository;
+
+import com.meetkey.server.domain.match.dto.RecommendationReqDTO;
+import com.meetkey.server.domain.member.entity.Member;
+
+import java.util.List;
+
+public interface MatchRepositoryCustom {
+    List<Member> findRecommendableMembers(Member member, RecommendationReqDTO request, List<Long> excludedIds, int limit);
+
+    List<Member> findRandomMembers(Member member, RecommendationReqDTO request, List<Long> excludedIds, int limit);
+}

--- a/src/main/java/com/meetkey/server/domain/match/repository/MatchRepositoryImpl.java
+++ b/src/main/java/com/meetkey/server/domain/match/repository/MatchRepositoryImpl.java
@@ -2,11 +2,18 @@ package com.meetkey.server.domain.match.repository;
 
 import com.meetkey.server.domain.match.dto.RecommendationReqDTO;
 import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.entity.QInterest;
 import com.meetkey.server.domain.member.entity.QMember;
+import com.meetkey.server.domain.member.entity.mapping.QInterestMember;
+import com.meetkey.server.domain.member.entity.mapping.QMemberLocation;
 import com.meetkey.server.domain.member.enums.Status;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -17,15 +24,13 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
     @Override
     public List<Member> findRecommendableMembers(Member member, RecommendationReqDTO request, List<Long> excludedIds, int limit) {
         QMember qMember = QMember.member;
-        com.querydsl.core.BooleanBuilder builder = new com.querydsl.core.BooleanBuilder();
+        BooleanBuilder builder = new BooleanBuilder();
 
         // 1. 기본 필터 (상태, 본인 제외, 기 스와이프 유저 제외)
         builder.and(qMember.status.eq(Status.ACTIVE));
         builder.and(qMember.id.ne(member.getId()));
         builder.and(qMember.id.notIn(excludedIds));
-        if (member.getGender() != null) {
-            builder.and(qMember.gender.ne(member.getGender()));
-        }
+
 
         // 2. DTO 기반 동적 필터링
         if (request.homeTown() != null && !request.homeTown().isEmpty())
@@ -39,18 +44,18 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
 
         // 나이 필터 (한국 만 나이 계산: 현재 연도 - 생년 + 1)
         if (request.minAge() != null) {
-            builder.and(qMember.birthday.year().loe(java.time.LocalDate.now().getYear() + 1 - request.minAge()));
+            builder.and(qMember.birthday.year().loe(LocalDate.now().getYear() + 1 - request.minAge()));
         }
         if (request.maxAge() != null) {
-            builder.and(qMember.birthday.year().goe(java.time.LocalDate.now().getYear() + 1 - request.maxAge()));
+            builder.and(qMember.birthday.year().goe(LocalDate.now().getYear() + 1 - request.maxAge()));
         }
 
         var query = queryFactory.selectFrom(qMember);
 
         // 관심사 필터 (Join 필요)
         if (request.interests() != null && !request.interests().isEmpty()) {
-            com.meetkey.server.domain.member.entity.mapping.QInterestMember qInterestMember = com.meetkey.server.domain.member.entity.mapping.QInterestMember.interestMember;
-            com.meetkey.server.domain.member.entity.QInterest qInterest = com.meetkey.server.domain.member.entity.QInterest.interest;
+            QInterestMember qInterestMember = QInterestMember.interestMember;
+            QInterest qInterest = QInterest.interest;
 
             query.leftJoin(qMember.interestMembers, qInterestMember)
                 .leftJoin(qInterestMember.interest, qInterest);
@@ -60,11 +65,11 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
 
         // 거리 필터 (Join, Haversine 공식)
         if (request.maxDistance() != null && request.latitude() != null && request.longitude() != null) {
-            com.meetkey.server.domain.member.entity.mapping.QMemberLocation qMemberLocation = com.meetkey.server.domain.member.entity.mapping.QMemberLocation.memberLocation;
+            QMemberLocation qMemberLocation = QMemberLocation.memberLocation;
             query.leftJoin(qMemberLocation).on(qMemberLocation.member.eq(qMember));
 
             // Haversine 공식 (km 단위)
-            com.querydsl.core.types.dsl.NumberExpression<Double> distanceExpression = com.querydsl.core.types.dsl.Expressions.numberTemplate(Double.class,
+            NumberExpression<Double> distanceExpression = Expressions.numberTemplate(Double.class,
                 "6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({0})) * sin(radians({1})))",
                 request.latitude(), qMemberLocation.latitude, qMemberLocation.longitude, request.longitude());
 
@@ -80,15 +85,13 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
     @Override
     public List<Member> findRandomMembers(Member member, RecommendationReqDTO request, List<Long> excludedIds, int limit) {
         QMember qMember = QMember.member;
-        com.querydsl.core.BooleanBuilder builder = new com.querydsl.core.BooleanBuilder();
+        BooleanBuilder builder = new BooleanBuilder();
 
         // 1. 기본 필터
         builder.and(qMember.status.eq(Status.ACTIVE));
         builder.and(qMember.id.ne(member.getId()));
         builder.and(qMember.id.notIn(excludedIds));
-        if (member.getGender() != null) {
-            builder.and(qMember.gender.ne(member.getGender()));
-        }
+
 
         // 2. 엄격한 백필 필터 (나이, 거리만 적용)
         // 나이 필터
@@ -103,10 +106,10 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
 
         // 거리 필터
         if (request.maxDistance() != null && request.latitude() != null && request.longitude() != null) {
-            com.meetkey.server.domain.member.entity.mapping.QMemberLocation qMemberLocation = com.meetkey.server.domain.member.entity.mapping.QMemberLocation.memberLocation;
+            QMemberLocation qMemberLocation = QMemberLocation.memberLocation;
             query.leftJoin(qMemberLocation).on(qMemberLocation.member.eq(qMember));
 
-            com.querydsl.core.types.dsl.NumberExpression<Double> distanceExpression = com.querydsl.core.types.dsl.Expressions.numberTemplate(Double.class,
+            NumberExpression<Double> distanceExpression = Expressions.numberTemplate(Double.class,
                 "6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({0})) * sin(radians({1})))",
                 request.latitude(), qMemberLocation.latitude, qMemberLocation.longitude, request.longitude());
 
@@ -115,7 +118,7 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
         }
 
         return query.where(builder)
-            .orderBy(com.querydsl.core.types.dsl.Expressions.numberTemplate(Double.class, "RAND()").asc())
+            .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
             .limit(limit)
             .fetch();
     }

--- a/src/main/java/com/meetkey/server/domain/match/repository/MatchRepositoryImpl.java
+++ b/src/main/java/com/meetkey/server/domain/match/repository/MatchRepositoryImpl.java
@@ -1,0 +1,122 @@
+package com.meetkey.server.domain.match.repository;
+
+import com.meetkey.server.domain.match.dto.RecommendationReqDTO;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.entity.QMember;
+import com.meetkey.server.domain.member.enums.Status;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MatchRepositoryImpl implements MatchRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Member> findRecommendableMembers(Member member, RecommendationReqDTO request, List<Long> excludedIds, int limit) {
+        QMember qMember = QMember.member;
+        com.querydsl.core.BooleanBuilder builder = new com.querydsl.core.BooleanBuilder();
+
+        // 1. 기본 필터 (상태, 본인 제외, 기 스와이프 유저 제외)
+        builder.and(qMember.status.eq(Status.ACTIVE));
+        builder.and(qMember.id.ne(member.getId()));
+        builder.and(qMember.id.notIn(excludedIds));
+        if (member.getGender() != null) {
+            builder.and(qMember.gender.ne(member.getGender()));
+        }
+
+        // 2. DTO 기반 동적 필터링
+        if (request.homeTown() != null && !request.homeTown().isEmpty())
+            builder.and(qMember.homeTown.in(request.homeTown()));
+        if (request.nativeLanguage() != null && !request.nativeLanguage().isEmpty())
+            builder.and(qMember.firstLanguage.in(request.nativeLanguage()));
+        if (request.targetLanguage() != null && !request.targetLanguage().isEmpty())
+            builder.and(qMember.targetLanguage.in(request.targetLanguage()));
+        if (request.targetLanguageLevel() != null && !request.targetLanguageLevel().isEmpty())
+            builder.and(qMember.targetLanguageLevel.in(request.targetLanguageLevel()));
+
+        // 나이 필터 (한국 만 나이 계산: 현재 연도 - 생년 + 1)
+        if (request.minAge() != null) {
+            builder.and(qMember.birthday.year().loe(java.time.LocalDate.now().getYear() + 1 - request.minAge()));
+        }
+        if (request.maxAge() != null) {
+            builder.and(qMember.birthday.year().goe(java.time.LocalDate.now().getYear() + 1 - request.maxAge()));
+        }
+
+        var query = queryFactory.selectFrom(qMember);
+
+        // 관심사 필터 (Join 필요)
+        if (request.interests() != null && !request.interests().isEmpty()) {
+            com.meetkey.server.domain.member.entity.mapping.QInterestMember qInterestMember = com.meetkey.server.domain.member.entity.mapping.QInterestMember.interestMember;
+            com.meetkey.server.domain.member.entity.QInterest qInterest = com.meetkey.server.domain.member.entity.QInterest.interest;
+
+            query.leftJoin(qMember.interestMembers, qInterestMember)
+                .leftJoin(qInterestMember.interest, qInterest);
+            builder.and(qInterest.type.in(request.interests()));
+            query.distinct();
+        }
+
+        // 거리 필터 (Join, Haversine 공식)
+        if (request.maxDistance() != null && request.latitude() != null && request.longitude() != null) {
+            com.meetkey.server.domain.member.entity.mapping.QMemberLocation qMemberLocation = com.meetkey.server.domain.member.entity.mapping.QMemberLocation.memberLocation;
+            query.leftJoin(qMemberLocation).on(qMemberLocation.member.eq(qMember));
+
+            // Haversine 공식 (km 단위)
+            com.querydsl.core.types.dsl.NumberExpression<Double> distanceExpression = com.querydsl.core.types.dsl.Expressions.numberTemplate(Double.class,
+                "6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({0})) * sin(radians({1})))",
+                request.latitude(), qMemberLocation.latitude, qMemberLocation.longitude, request.longitude());
+
+            builder.and(qMemberLocation.isNotNull()); // 위치 정보가 있는 경우만
+            builder.and(distanceExpression.loe(request.maxDistance()));
+        }
+
+        return query.where(builder)
+            .limit(limit)
+            .fetch();
+    }
+
+    @Override
+    public List<Member> findRandomMembers(Member member, RecommendationReqDTO request, List<Long> excludedIds, int limit) {
+        QMember qMember = QMember.member;
+        com.querydsl.core.BooleanBuilder builder = new com.querydsl.core.BooleanBuilder();
+
+        // 1. 기본 필터
+        builder.and(qMember.status.eq(Status.ACTIVE));
+        builder.and(qMember.id.ne(member.getId()));
+        builder.and(qMember.id.notIn(excludedIds));
+        if (member.getGender() != null) {
+            builder.and(qMember.gender.ne(member.getGender()));
+        }
+
+        // 2. 엄격한 백필 필터 (나이, 거리만 적용)
+        // 나이 필터
+        if (request.minAge() != null) {
+            builder.and(qMember.birthday.year().loe(java.time.LocalDate.now().getYear() + 1 - request.minAge()));
+        }
+        if (request.maxAge() != null) {
+            builder.and(qMember.birthday.year().goe(java.time.LocalDate.now().getYear() + 1 - request.maxAge()));
+        }
+
+        var query = queryFactory.selectFrom(qMember);
+
+        // 거리 필터
+        if (request.maxDistance() != null && request.latitude() != null && request.longitude() != null) {
+            com.meetkey.server.domain.member.entity.mapping.QMemberLocation qMemberLocation = com.meetkey.server.domain.member.entity.mapping.QMemberLocation.memberLocation;
+            query.leftJoin(qMemberLocation).on(qMemberLocation.member.eq(qMember));
+
+            com.querydsl.core.types.dsl.NumberExpression<Double> distanceExpression = com.querydsl.core.types.dsl.Expressions.numberTemplate(Double.class,
+                "6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({0})) * sin(radians({1})))",
+                request.latitude(), qMemberLocation.latitude, qMemberLocation.longitude, request.longitude());
+
+            builder.and(qMemberLocation.isNotNull());
+            builder.and(distanceExpression.loe(request.maxDistance()));
+        }
+
+        return query.where(builder)
+            .orderBy(com.querydsl.core.types.dsl.Expressions.numberTemplate(Double.class, "RAND()").asc())
+            .limit(limit)
+            .fetch();
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/match/repository/RecommendationQueueRepository.java
+++ b/src/main/java/com/meetkey/server/domain/match/repository/RecommendationQueueRepository.java
@@ -1,19 +1,14 @@
 package com.meetkey.server.domain.match.repository;
 
-import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.match.entity.RecommendationQueue;
-import org.springframework.data.domain.Sort;
+import com.meetkey.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface RecommendationQueueRepository extends JpaRepository<RecommendationQueue, Long> {
-    List<RecommendationQueue> findAllByMemberAndIsSwipedFalse(Member member, Sort sort);
-    
-    // For cleaning up old queue if needed or checking count
-    long countByMemberAndIsSwipedFalse(Member member);
-    
-    java.util.Optional<RecommendationQueue> findByMemberAndTargetMember(Member member, Member targetMember);
 
-    List<RecommendationQueue> findTop10ByMemberAndIsSwipedTrueAndIsRecycledFalseOrderByUpdateAtDesc(Member member);
+    Optional<RecommendationQueue> findByMemberAndTargetMember(Member member, Member targetMember);
+
+    void deleteByMemberAndIsSwipedFalse(Member member);
 }

--- a/src/main/java/com/meetkey/server/domain/match/repository/RecommendationQueueRepository.java
+++ b/src/main/java/com/meetkey/server/domain/match/repository/RecommendationQueueRepository.java
@@ -1,0 +1,19 @@
+package com.meetkey.server.domain.match.repository;
+
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.match.entity.RecommendationQueue;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecommendationQueueRepository extends JpaRepository<RecommendationQueue, Long> {
+    List<RecommendationQueue> findAllByMemberAndIsSwipedFalse(Member member, Sort sort);
+    
+    // For cleaning up old queue if needed or checking count
+    long countByMemberAndIsSwipedFalse(Member member);
+    
+    java.util.Optional<RecommendationQueue> findByMemberAndTargetMember(Member member, Member targetMember);
+
+    List<RecommendationQueue> findTop10ByMemberAndIsSwipedTrueAndIsRecycledFalseOrderByUpdateAtDesc(Member member);
+}

--- a/src/main/java/com/meetkey/server/domain/match/service/MatchService.java
+++ b/src/main/java/com/meetkey/server/domain/match/service/MatchService.java
@@ -1,0 +1,13 @@
+package com.meetkey.server.domain.match.service;
+
+import com.meetkey.server.domain.match.dto.MatchListResDTO;
+import com.meetkey.server.domain.match.dto.RecommendationReqDTO;
+import com.meetkey.server.domain.match.dto.SwipeReqDTO;
+import com.meetkey.server.domain.match.dto.SwipeResDTO;
+import com.meetkey.server.domain.member.entity.Member;
+
+public interface MatchService {
+    MatchListResDTO getRecommendations(Member member, RecommendationReqDTO request);
+
+    SwipeResDTO swipe(Member member, SwipeReqDTO request);
+}

--- a/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
+++ b/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
@@ -12,6 +12,8 @@ import com.meetkey.server.domain.member.entity.mapping.MemberLocation;
 import com.meetkey.server.domain.member.repository.MemberLikeRepository;
 import com.meetkey.server.domain.member.repository.MemberLocationRepository;
 import com.meetkey.server.domain.member.repository.MemberRepository;
+import com.meetkey.server.domain.member.entity.Preference;
+import com.meetkey.server.domain.member.repository.PreferenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,6 +36,7 @@ public class MatchServiceImpl implements MatchService {
     private final MemberLikeRepository memberLikeRepository;
     private final MemberLocationRepository memberLocationRepository;
     private final MemberRepository memberRepository;
+    private final PreferenceRepository preferenceRepository;
     private final RecommendationQueueRepository recommendationQueueRepository;
 
     @Override
@@ -91,13 +95,19 @@ public class MatchServiceImpl implements MatchService {
         List<Member> candidates = matchRepository.findRecommendableMembers(member, request, excludedIds, 100);
 
         // 3. 소프트 스코어링 (점수 계산)
-        // 3. 소프트 스코어링 (점수 계산)
         MemberLocation myLocation = memberLocationRepository.findByMember(member).orElse(null);
-        // Preference myPreference = preferenceRepository.findByMember(member).orElse(null); // 생략
+        Preference myPreference = preferenceRepository.findById(member.getId()).orElse(null);
+
+        // 후보자들의 Preference 일괄 조회
+        List<Long> candidateIds = candidates.stream().map(Member::getId).collect(Collectors.toList());
+        List<Preference> preferences = preferenceRepository.findAllById(candidateIds);
+        Map<Long, Preference> prefMap = preferences.stream()
+            .collect(Collectors.toMap(p -> p.getMember().getId(), p -> p));
 
         List<MemberScore> scoredCandidates = candidates.stream()
             .map(candidate -> {
-                double score = calculateScore(member, myLocation, candidate);
+                Preference targetPref = prefMap.get(candidate.getId());
+                double score = calculateScore(member, myLocation, myPreference, candidate, targetPref);
                 return new MemberScore(candidate, score);
             })
             .sorted((p1, p2) -> Double.compare(p2.score, p1.score))
@@ -111,9 +121,15 @@ public class MatchServiceImpl implements MatchService {
             List<Long> allExcluded = new ArrayList<>(excludedIds);
             allExcluded.addAll(currentIds);
 
-            List<Member> randomMembers = matchRepository.findRandomMembers(member, request, allExcluded, needed);
+            List<Member> randomMembers = matchRepository.findRandomMembers(member, request, allExcluded, needed); // 랜덤 멤버는 Preference 점수 0 처리 (또는 조회 로직 추가 필요)
 
-            randomMembers.forEach(rm -> scoredCandidates.add(new MemberScore(rm, 0.0)));
+            randomMembers.forEach(rm -> {
+                // 랜덤 멤버의 Preference 조회 (개별 조회 허용 or 추가 벌크 조회) - 여기선 개별 조회
+                // Preference randomPref = preferenceRepository.findById(rm.getId()).orElse(null);
+                // scoredCandidates.add(new MemberScore(rm, 0.0)); // 점수는 0
+                // DTO 변환 시 필요하므로, 일단 점수 매기는 로직에 넣지 말고 0으로 하고, DTO 변환 시 조회하도록 함.
+                scoredCandidates.add(new MemberScore(rm, 0.0));
+            });
         }
 
         // 4. 큐에 저장
@@ -123,18 +139,24 @@ public class MatchServiceImpl implements MatchService {
                 .targetMember(ms.member())
                 .score(ms.score())
                 .isSwiped(false)
-                .isRecycled(false) // 재활용 로직 필요 시 반영
+                .isRecycled(false)
                 .build())
             .collect(Collectors.toList());
 
         recommendationQueueRepository.saveAll(queueEntities);
 
         return scoredCandidates.stream()
-            .map(ms -> convertToDTO(ms.member))
+            .map(ms -> {
+                // 백필된 멤버의 경우 prefMap에 없을 수 있음
+                Preference targetPref = prefMap.containsKey(ms.member().getId()) ? 
+                                        prefMap.get(ms.member().getId()) : 
+                                        preferenceRepository.findById(ms.member().getId()).orElse(null);
+                return convertToDTO(ms.member(), targetPref);
+            })
             .collect(Collectors.toList());
     }
 
-    private double calculateScore(Member me, MemberLocation myLoc, Member target) {
+    private double calculateScore(Member me, MemberLocation myLoc, Preference myPref, Member target, Preference targetPref) {
         double score = 0;
 
         // 1. 언어 점수 (최대 +5점)
@@ -146,12 +168,15 @@ public class MatchServiceImpl implements MatchService {
         else if (me.getTargetLanguage() == target.getTargetLanguage()) score += 1;
 
         // 2. 성격 점수 (최대 +5점)
-        if (me.getTargetLanguage() == target.getTargetLanguage()) score += 1;
+        if (myPref != null && targetPref != null) {
+            if (myPref.getSocialType() == targetPref.getSocialType()) score += 1;
+            if (myPref.getMeetingType() == targetPref.getMeetingType()) score += 1;
+            if (myPref.getChatType() == targetPref.getChatType()) score += 1;
+            if (myPref.getFriendType() == targetPref.getFriendType()) score += 1;
+            if (myPref.getRelationType() == targetPref.getRelationType()) score += 1;
+        }
 
-        // 2. 성격 (PreferenceRepository 제한으로 인해 일단 생략)
-        // if (myPref != null) {  }
-
-        // 3. Interests (+N)
+        // 3. 관심사 점수 (+N점)
 
         // 3. 관심사 점수 (+N점)
         List<String> myInterests = me.getInterestMembers().stream()
@@ -194,12 +219,24 @@ public class MatchServiceImpl implements MatchService {
     }
 
     private RecommendationResDTO convertToDTO(Member member) {
+        // Recycle 모드 등 단일 조회 시 사용
+        Preference pref = preferenceRepository.findById(member.getId()).orElse(null);
+        return convertToDTO(member, pref);
+    }
+
+    private RecommendationResDTO convertToDTO(Member member, Preference pref) {
         int age = member.getBirthday() != null ? LocalDate.now().getYear() - member.getBirthday().getYear() + 1 : 0;
 
-        // DTO 변환 시 Preference 정보 필요
-        // (일단 생략)
-        // PreferenceRepository 사용 안 함.
         RecommendationResDTO.PersonalityDTO personalityDTO = null;
+        if (pref != null) {
+            personalityDTO = RecommendationResDTO.PersonalityDTO.builder()
+                .socialType(pref.getSocialType())
+                .meetingType(pref.getMeetingType())
+                .chatType(pref.getChatType())
+                .friendType(pref.getFriendType())
+                .relationType(pref.getRelationType())
+                .build();
+        }
 
         // 관심사 목록 조회
         List<String> interests = member.getInterestMembers().stream()

--- a/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
+++ b/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
@@ -1,8 +1,10 @@
 package com.meetkey.server.domain.match.service;
 
 import com.meetkey.server.domain.match.dto.*;
+import com.meetkey.server.domain.match.entity.RecommendationQueue;
 import com.meetkey.server.domain.match.enums.MatchType;
 import com.meetkey.server.domain.match.repository.MatchRepository;
+import com.meetkey.server.domain.match.repository.RecommendationQueueRepository;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.member.entity.mapping.FromToId;
 import com.meetkey.server.domain.member.entity.mapping.MemberLike;
@@ -10,14 +12,13 @@ import com.meetkey.server.domain.member.entity.mapping.MemberLocation;
 import com.meetkey.server.domain.member.repository.MemberLikeRepository;
 import com.meetkey.server.domain.member.repository.MemberLocationRepository;
 import com.meetkey.server.domain.member.repository.MemberRepository;
-import com.meetkey.server.domain.match.entity.RecommendationQueue;
-import com.meetkey.server.domain.match.repository.RecommendationQueueRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,59 +38,38 @@ public class MatchServiceImpl implements MatchService {
     @Override
     @Transactional
     public MatchListResDTO getRecommendations(Member member, RecommendationReqDTO request) {
-        // 1. 추천 큐 확인
-        List<RecommendationQueue> queue = recommendationQueueRepository.findAllByMemberAndIsSwipedFalse(member, Sort.by(Sort.Direction.DESC, "score"));
+        // 0. 기존 큐 초기화 (필터 변경 시 반영을 위해)
+        recommendationQueueRepository.deleteByMemberAndIsSwipedFalse(member);
 
-        if (!queue.isEmpty()) {
-            boolean isRecycled = queue.get(0).getIsRecycled();
-            MatchType currentType = isRecycled ? MatchType.RECYCLE : MatchType.DAILY_MATCH;
-            List<RecommendationResDTO> dtos = queue.stream()
-                .map(q -> convertToDTO(q.getTargetMember()))
+        // 1. 금일 스와이프 횟수 확인 (일일 제한 10명)
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
+        long todaySwipes = memberLikeRepository.countByFromMemberAndCreatedAtBetween(member, startOfDay, endOfDay);
+        int remainingQuota = Math.max(0, 10 - (int) todaySwipes);
+
+        // 2. 분기 처리: 일일 할당량 남음 vs 소진 (Recycle)
+        if (remainingQuota > 0) {
+            // A. Daily Match Mode (새로울 후보 생성)
+            // 할당량(remainingQuota)만큼만 생성
+            List<RecommendationResDTO> newRecommendations = generateRecommendations(member, request, remainingQuota);
+            return buildResponse(newRecommendations, newRecommendations.size(), MatchType.DAILY_MATCH);
+
+        } else {
+            // B. Recycle Mode (할당량 소진 시)
+            // 재활용 대상: DISLIKE 했거나, LIKE 했지만 채팅 시작 안 한 유저
+            List<Member> recycleMembers = memberLikeRepository.findRecycleMembers(member);
+
+            // 랜덤으로 섞어서 반환 (또는 최신순 등)
+            Collections.shuffle(recycleMembers);
+            List<Member> limitedRecycle = recycleMembers.stream().limit(10).toList();
+
+            // 여기서는 단순 조회로 반환
+            List<RecommendationResDTO> dtos = limitedRecycle.stream()
+                .map(this::convertToDTO)
                 .collect(Collectors.toList());
-            return buildResponse(dtos, queue.size(), currentType);
+
+            return buildResponse(dtos, dtos.size(), MatchType.RECYCLE);
         }
-
-        // 2. 재활용 시도 (이미 스와이프한 유저가 있다면)
-        List<RecommendationQueue> recycleCandidates = recommendationQueueRepository.findTop10ByMemberAndIsSwipedTrueAndIsRecycledFalseOrderByUpdateAtDesc(member);
-
-        // 이미 매칭된 유저는 제외
-        List<RecommendationQueue> validRecycle = new ArrayList<>();
-        for (RecommendationQueue item : recycleCandidates) {
-            Member target = item.getTargetMember();
-            // MemberLike 상태 확인
-            MemberLike interaction = memberLikeRepository.findById(new FromToId(member.getId(), target.getId())).orElse(null);
-
-            // 이미 매칭된 경우 스킵 (이미 성공한 관계)
-            if (interaction != null && interaction.getIsMatched() != null && interaction.getIsMatched()) {
-                continue;
-            }
-            validRecycle.add(item);
-        }
-
-        if (!validRecycle.isEmpty()) {
-            // 큐 아이템 상태를 재활용으로 업데이트
-            validRecycle.forEach(RecommendationQueue::recycle);
-            recommendationQueueRepository.saveAll(validRecycle);
-
-            List<RecommendationResDTO> dtos = validRecycle.stream()
-                .map(q -> convertToDTO(q.getTargetMember()))
-                .collect(Collectors.toList());
-            return buildResponse(dtos, validRecycle.size(), MatchType.RECYCLE);
-        }
-
-        // 3. 새로운 후보 생성 (하드 필터링 & 스코어링)
-        List<RecommendationResDTO> newRecommendations = generateRecommendations(member, request);
-        MatchType type = MatchType.DAILY_MATCH;
-
-        // 결과가 비어있으면 랜덤 또는 재활용 시도 (로직: 필터 결과 0명 -> 랜덤)
-        if (newRecommendations.isEmpty()) {
-            // 랜덤 유저 백필 (generateRecommendations 내부에서 이미 처리됨)
-        }
-
-        // 큐에 저장
-        // DB 저장은 일단 생략, 로직 반환에 집중
-
-        return buildResponse(newRecommendations, 10, type); // 총 개수 모킹
     }
 
     private MatchListResDTO buildResponse(List<RecommendationResDTO> list, int remaining, MatchType type) {
@@ -103,7 +83,7 @@ public class MatchServiceImpl implements MatchService {
             .build();
     }
 
-    private List<RecommendationResDTO> generateRecommendations(Member member, RecommendationReqDTO request) {
+    private List<RecommendationResDTO> generateRecommendations(Member member, RecommendationReqDTO request, int limit) {
         // 1. 기 스와이프 유저 제외
         List<Long> excludedIds = memberLikeRepository.findSwipedMemberIdsByMember(member);
 
@@ -113,7 +93,7 @@ public class MatchServiceImpl implements MatchService {
         // 3. 소프트 스코어링 (점수 계산)
         // 3. 소프트 스코어링 (점수 계산)
         MemberLocation myLocation = memberLocationRepository.findByMember(member).orElse(null);
-        // Preference myPreference = preferenceRepository.findByMember(member).orElse(null); // Removed
+        // Preference myPreference = preferenceRepository.findByMember(member).orElse(null); // 생략
 
         List<MemberScore> scoredCandidates = candidates.stream()
             .map(candidate -> {
@@ -121,13 +101,12 @@ public class MatchServiceImpl implements MatchService {
                 return new MemberScore(candidate, score);
             })
             .sorted((p1, p2) -> Double.compare(p2.score, p1.score))
-            .limit(10)
-            .limit(10)
+            .limit(limit)
             .collect(Collectors.toList());
 
         // 10명 미만일 경우 랜덤 유저 백필 (엄격한 조건 적용)
-        if (scoredCandidates.size() < 10) {
-            int needed = 10 - scoredCandidates.size();
+        if (scoredCandidates.size() < limit) {
+            int needed = limit - scoredCandidates.size();
             List<Long> currentIds = scoredCandidates.stream().map(ms -> ms.member().getId()).collect(Collectors.toList());
             List<Long> allExcluded = new ArrayList<>(excludedIds);
             allExcluded.addAll(currentIds);

--- a/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
+++ b/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
@@ -1,0 +1,280 @@
+package com.meetkey.server.domain.match.service;
+
+import com.meetkey.server.domain.match.dto.*;
+import com.meetkey.server.domain.match.enums.MatchType;
+import com.meetkey.server.domain.match.repository.MatchRepository;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.entity.mapping.FromToId;
+import com.meetkey.server.domain.member.entity.mapping.MemberLike;
+import com.meetkey.server.domain.member.entity.mapping.MemberLocation;
+import com.meetkey.server.domain.member.repository.MemberLikeRepository;
+import com.meetkey.server.domain.member.repository.MemberLocationRepository;
+import com.meetkey.server.domain.member.repository.MemberRepository;
+import com.meetkey.server.domain.match.entity.RecommendationQueue;
+import com.meetkey.server.domain.match.repository.RecommendationQueueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchServiceImpl implements MatchService {
+
+    private final MatchRepository matchRepository;
+    private final MemberLikeRepository memberLikeRepository;
+    private final MemberLocationRepository memberLocationRepository;
+    private final MemberRepository memberRepository;
+    private final RecommendationQueueRepository recommendationQueueRepository;
+
+    @Override
+    @Transactional
+    public MatchListResDTO getRecommendations(Member member, RecommendationReqDTO request) {
+        // 1. 추천 큐 확인
+        List<RecommendationQueue> queue = recommendationQueueRepository.findAllByMemberAndIsSwipedFalse(member, Sort.by(Sort.Direction.DESC, "score"));
+
+        if (!queue.isEmpty()) {
+            boolean isRecycled = queue.get(0).getIsRecycled();
+            MatchType currentType = isRecycled ? MatchType.RECYCLE : MatchType.DAILY_MATCH;
+            List<RecommendationResDTO> dtos = queue.stream()
+                .map(q -> convertToDTO(q.getTargetMember()))
+                .collect(Collectors.toList());
+            return buildResponse(dtos, queue.size(), currentType);
+        }
+
+        // 2. 재활용 시도 (이미 스와이프한 유저가 있다면)
+        List<RecommendationQueue> recycleCandidates = recommendationQueueRepository.findTop10ByMemberAndIsSwipedTrueAndIsRecycledFalseOrderByUpdateAtDesc(member);
+
+        // 이미 매칭된 유저는 제외
+        List<RecommendationQueue> validRecycle = new ArrayList<>();
+        for (RecommendationQueue item : recycleCandidates) {
+            Member target = item.getTargetMember();
+            // MemberLike 상태 확인
+            MemberLike interaction = memberLikeRepository.findById(new FromToId(member.getId(), target.getId())).orElse(null);
+
+            // 이미 매칭된 경우 스킵 (이미 성공한 관계)
+            if (interaction != null && interaction.getIsMatched() != null && interaction.getIsMatched()) {
+                continue;
+            }
+            validRecycle.add(item);
+        }
+
+        if (!validRecycle.isEmpty()) {
+            // 큐 아이템 상태를 재활용으로 업데이트
+            validRecycle.forEach(RecommendationQueue::recycle);
+            recommendationQueueRepository.saveAll(validRecycle);
+
+            List<RecommendationResDTO> dtos = validRecycle.stream()
+                .map(q -> convertToDTO(q.getTargetMember()))
+                .collect(Collectors.toList());
+            return buildResponse(dtos, validRecycle.size(), MatchType.RECYCLE);
+        }
+
+        // 3. 새로운 후보 생성 (하드 필터링 & 스코어링)
+        List<RecommendationResDTO> newRecommendations = generateRecommendations(member, request);
+        MatchType type = MatchType.DAILY_MATCH;
+
+        // 결과가 비어있으면 랜덤 또는 재활용 시도 (로직: 필터 결과 0명 -> 랜덤)
+        if (newRecommendations.isEmpty()) {
+            // 랜덤 유저 백필 (generateRecommendations 내부에서 이미 처리됨)
+        }
+
+        // 큐에 저장
+        // DB 저장은 일단 생략, 로직 반환에 집중
+
+        return buildResponse(newRecommendations, 10, type); // 총 개수 모킹
+    }
+
+    private MatchListResDTO buildResponse(List<RecommendationResDTO> list, int remaining, MatchType type) {
+        return MatchListResDTO.builder()
+            .recommendations(list)
+            .swipeInfo(MatchListResDTO.SwipeInfoDTO.builder()
+                .remainingCount(remaining)
+                .totalCount(10)
+                .build())
+            .matchType(type)
+            .build();
+    }
+
+    private List<RecommendationResDTO> generateRecommendations(Member member, RecommendationReqDTO request) {
+        // 1. 기 스와이프 유저 제외
+        List<Long> excludedIds = memberLikeRepository.findSwipedMemberIdsByMember(member);
+
+        // 2. 하드 필터 (QueryDSL)
+        List<Member> candidates = matchRepository.findRecommendableMembers(member, request, excludedIds, 100);
+
+        // 3. 소프트 스코어링 (점수 계산)
+        // 3. 소프트 스코어링 (점수 계산)
+        MemberLocation myLocation = memberLocationRepository.findByMember(member).orElse(null);
+        // Preference myPreference = preferenceRepository.findByMember(member).orElse(null); // Removed
+
+        List<MemberScore> scoredCandidates = candidates.stream()
+            .map(candidate -> {
+                double score = calculateScore(member, myLocation, candidate);
+                return new MemberScore(candidate, score);
+            })
+            .sorted((p1, p2) -> Double.compare(p2.score, p1.score))
+            .limit(10)
+            .limit(10)
+            .collect(Collectors.toList());
+
+        // 10명 미만일 경우 랜덤 유저 백필 (엄격한 조건 적용)
+        if (scoredCandidates.size() < 10) {
+            int needed = 10 - scoredCandidates.size();
+            List<Long> currentIds = scoredCandidates.stream().map(ms -> ms.member().getId()).collect(Collectors.toList());
+            List<Long> allExcluded = new ArrayList<>(excludedIds);
+            allExcluded.addAll(currentIds);
+
+            List<Member> randomMembers = matchRepository.findRandomMembers(member, request, allExcluded, needed);
+
+            randomMembers.forEach(rm -> scoredCandidates.add(new MemberScore(rm, 0.0)));
+        }
+
+        // 4. 큐에 저장
+        List<RecommendationQueue> queueEntities = scoredCandidates.stream()
+            .map(ms -> RecommendationQueue.builder()
+                .member(member)
+                .targetMember(ms.member())
+                .score(ms.score())
+                .isSwiped(false)
+                .isRecycled(false) // 재활용 로직 필요 시 반영
+                .build())
+            .collect(Collectors.toList());
+
+        recommendationQueueRepository.saveAll(queueEntities);
+
+        return scoredCandidates.stream()
+            .map(ms -> convertToDTO(ms.member))
+            .collect(Collectors.toList());
+    }
+
+    private double calculateScore(Member me, MemberLocation myLoc, Member target) {
+        double score = 0;
+
+        // 1. 언어 점수 (최대 +5점)
+        boolean meTargetMatch = me.getTargetLanguage() == target.getFirstLanguage();
+        boolean targetTargetMatch = target.getTargetLanguage() == me.getFirstLanguage();
+
+        if (meTargetMatch && targetTargetMatch) score += 5;
+        else if (meTargetMatch || targetTargetMatch) score += 3;
+        else if (me.getTargetLanguage() == target.getTargetLanguage()) score += 1;
+
+        // 2. 성격 점수 (최대 +5점)
+        if (me.getTargetLanguage() == target.getTargetLanguage()) score += 1;
+
+        // 2. 성격 (PreferenceRepository 제한으로 인해 일단 생략)
+        // if (myPref != null) {  }
+
+        // 3. Interests (+N)
+
+        // 3. 관심사 점수 (+N점)
+        List<String> myInterests = me.getInterestMembers().stream()
+            .map(im -> im.getInterest().getType().name())
+            .toList();
+        List<String> targetInterests = target.getInterestMembers().stream()
+            .map(im -> im.getInterest().getType().name())
+            .toList();
+        score += myInterests.stream().filter(targetInterests::contains).count();
+
+        // 4. 보너스 점수 (+2점)
+        // 연령대 일치 (+1점)
+        if (me.getBirthday() != null && target.getBirthday() != null) {
+            int myAgeGroup = (LocalDate.now().getYear() - me.getBirthday().getYear()) / 10;
+            int targetAgeGroup = (LocalDate.now().getYear() - target.getBirthday().getYear()) / 10;
+            if (myAgeGroup == targetAgeGroup) score += 1;
+        }
+
+        // 거리 50km 이내 (+1점)
+        if (myLoc != null) {
+            MemberLocation targetLoc = memberLocationRepository.findByMember(target).orElse(null);
+            if (targetLoc != null) {
+                double dist = calculateDistance(myLoc.getLatitude(), myLoc.getLongitude(), targetLoc.getLatitude(), targetLoc.getLongitude());
+                if (dist <= 50.0) score += 1;
+            }
+        }
+
+        return score;
+    }
+
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double R = 6371;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+
+    private RecommendationResDTO convertToDTO(Member member) {
+        int age = member.getBirthday() != null ? LocalDate.now().getYear() - member.getBirthday().getYear() + 1 : 0;
+
+        // DTO 변환 시 Preference 정보 필요
+        // (일단 생략)
+        // PreferenceRepository 사용 안 함.
+        RecommendationResDTO.PersonalityDTO personalityDTO = null;
+
+        // 관심사 목록 조회
+        List<String> interests = member.getInterestMembers().stream()
+            .map(im -> im.getInterest().getType().name())
+            .collect(Collectors.toList());
+
+        return RecommendationResDTO.builder()
+            .targetMemberId(member.getId())
+            .nickname(member.getName())
+            .age(age)
+            .hometown(member.getHomeTown())
+            .distance(0.0) // 위치 정보 로직 생략 (0.0 반환)
+            .gender(member.getGender())
+            .nativeLanguage(RecommendationResDTO.LanguageDTO.builder()
+                .language(member.getFirstLanguage())
+                .level(null) // 본인 언어 레벨은 보통 null
+                .build())
+            .targetLanguage(RecommendationResDTO.LanguageDTO.builder()
+                .language(member.getTargetLanguage())
+                .level(member.getTargetLanguageLevel())
+                .build())
+            .interests(interests)
+            .personality(personalityDTO)
+            .photoUrls(Collections.emptyList()) // 플레이스홀더
+            .introduction(member.getBio())
+            .build();
+    }
+
+    @Override
+    @Transactional
+    public SwipeResDTO swipe(Member member, SwipeReqDTO request) {
+        Member target = memberRepository.findById(request.targetMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("Target member not found"));
+
+        // 좋아요/싫어요 저장
+        MemberLike memberLike = MemberLike.builder()
+            .memberLikeId(new FromToId(member.getId(), target.getId()))
+            .fromMember(member)
+            .toMember(target)
+            .action(request.action())
+            .isMatched(false) // 매칭(상호 좋아요) 확인 로직 추가 가능
+            .build();
+        memberLikeRepository.save(memberLike);
+
+        // 큐에서 스와이프 처리
+        recommendationQueueRepository.findByMemberAndTargetMember(member, target)
+            .ifPresent(RecommendationQueue::markSwiped);
+
+        return SwipeResDTO.builder()
+            .targetMemberId(target.getId())
+            .action(request.action())
+            .build();
+    }
+
+    private record MemberScore(Member member, double score) {
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/member/entity/Member.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/Member.java
@@ -72,12 +72,17 @@ public class Member extends BaseEntity {
     @Builder.Default
     private Integer notRecommendCount = 0;
 
+
+
+
+
     private String refreshToken;
     private LocalDateTime refreshTokenExpiration;
 
     /*
      * 관심사
      */
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<InterestMember> interestMembers = new ArrayList<>();
 

--- a/src/main/java/com/meetkey/server/domain/member/entity/mapping/FromToId.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/mapping/FromToId.java
@@ -14,4 +14,9 @@ public class FromToId {
     private Long fromId;
     @Column(name = "to_id")
     private Long toId;
+
+    public FromToId(Long fromId, Long toId) {
+        this.fromId = fromId;
+        this.toId = toId;
+    }
 }

--- a/src/main/java/com/meetkey/server/domain/member/entity/mapping/MemberLike.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/mapping/MemberLike.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.domain.member.entity.mapping;
 
+import com.meetkey.server.domain.match.enums.Action;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -29,7 +30,7 @@ public class MemberLike extends BaseEntity {
     private Boolean isMatched = false;
 
     @Enumerated(EnumType.STRING)
-    private com.meetkey.server.domain.match.enums.Action action;
+    private Action action;
 
     @Builder.Default
     private Boolean isChatStarted = false;

--- a/src/main/java/com/meetkey/server/domain/member/entity/mapping/MemberLike.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/mapping/MemberLike.java
@@ -27,4 +27,10 @@ public class MemberLike extends BaseEntity {
 
     @Builder.Default
     private Boolean isMatched = false;
+
+    @Enumerated(EnumType.STRING)
+    private com.meetkey.server.domain.match.enums.Action action;
+
+    @Builder.Default
+    private Boolean isChatStarted = false;
 }

--- a/src/main/java/com/meetkey/server/domain/member/enums/MembershipType.java
+++ b/src/main/java/com/meetkey/server/domain/member/enums/MembershipType.java
@@ -1,0 +1,12 @@
+package com.meetkey.server.domain.member.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MembershipType {
+    FREE,
+    PREMIUM
+    ;
+}

--- a/src/main/java/com/meetkey/server/domain/member/repository/MemberLikeRepository.java
+++ b/src/main/java/com/meetkey/server/domain/member/repository/MemberLikeRepository.java
@@ -1,0 +1,15 @@
+package com.meetkey.server.domain.member.repository;
+
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.entity.mapping.FromToId;
+import com.meetkey.server.domain.member.entity.mapping.MemberLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemberLikeRepository extends JpaRepository<MemberLike, FromToId> {
+    @Query("SELECT ml.toMember.id FROM MemberLike ml WHERE ml.fromMember = :member")
+    List<Long> findSwipedMemberIdsByMember(@Param("member") Member member);
+}

--- a/src/main/java/com/meetkey/server/domain/member/repository/MemberLikeRepository.java
+++ b/src/main/java/com/meetkey/server/domain/member/repository/MemberLikeRepository.java
@@ -7,9 +7,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MemberLikeRepository extends JpaRepository<MemberLike, FromToId> {
     @Query("SELECT ml.toMember.id FROM MemberLike ml WHERE ml.fromMember = :member")
     List<Long> findSwipedMemberIdsByMember(@Param("member") Member member);
+
+    long countByFromMemberAndCreatedAtBetween(Member fromMember, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT ml.toMember FROM MemberLike ml WHERE ml.fromMember = :member AND (ml.action = 'DISLIKE' OR (ml.action = 'LIKE' AND ml.isChatStarted = false))")
+    List<Member> findRecycleMembers(@Param("member") Member member);
 }

--- a/src/main/java/com/meetkey/server/global/config/QueryDslConfig.java
+++ b/src/main/java/com/meetkey/server/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.meetkey.server.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 요약
- 매칭 시스템 핵심 로직(필터링, 스코어링, 큐 관리) 구현
- 일일 추천 제한 및 재활용(Recycle) 기능을 구현했습니다.

<br>

## 연결된 이슈 번호
- close #12 

<br>

## 세부 작업 사항
- 매칭 알고리즘
  - 3단계 매칭 프로세스 구현: 필터링(사용자 설정) → 매칭 스코어링 → 저장 및 반환
  - QueryDSL 기반 필터링: 관심사, 나이, 거리, 언어, 거주지 등 다양한 조건에 대한 다중 선택(List) 필터링 지원
  - 랜덤 백필: 추천 후보 부족 시, 필터링을 만족하는 유저를 랜덤으로 채움
- 추천 정책 강화
  - 일일 추천 제한 (10명): 매일 최대 10명까지만 새로운 추천을 제공하며, 스와이프 횟수를 기반으로 잔여 할당량을 계산
  - 재활용(Recycle) 모드: 일일 할당량 소진 시, 이전에 '싫어요(DISLIKE)' 했거나 '매칭되지 않은 좋아요(LIKE)' 대상을 다시 추천
<br>

## Approve 하기 전에 확인할 것
- [ ] 채팅 기능 완료 후: 사용자가 '좋아요(LIKE)' 이후 상대방과 채팅이 이루어졌는지 확인 후 추천 큐에 해당 내용 반영할 예정임
- [x] 사용자 위치 정보 저장 API 개발 후 거리 기반 필터링 추가 예정임

<br>

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
