### PR TITLE
[FEAT] presigned url 구현 및 application 로컬, 배포 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,8 @@ jobs:
             cd /home/ec2-user/app
             
             # 환경변수 설정
+            export SPRING_PROFILES_ACTIVE=prod
+            export S3_BUCKET=${{ secrets.S3_BUCKET }}
             export IMAGE_TAG=${{ github.sha }}
             export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
             export DB_URL='${{ secrets.DB_URL }}'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     // feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    // AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.767'
+    implementation 'software.amazon.awssdk:s3:2.27.3'
+    implementation 'software.amazon.awssdk:s3control:2.27.3'
+    implementation 'software.amazon.awssdk:s3outposts:2.27.3'
     
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     ports:
       - "80:8080"
     environment:
+      SPRING_PROFILES_ACTIVE: prod
+      S3_BUCKET: ${S3_BUCKET}
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}
       DB_PW: ${DB_PW}

--- a/src/main/java/com/meetkey/server/global/config/S3Config.java
+++ b/src/main/java/com/meetkey/server/global/config/S3Config.java
@@ -1,0 +1,58 @@
+package com.meetkey.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key:}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key:}")
+    private String secretKey;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        S3Presigner.Builder builder = S3Presigner.builder()
+                .region(Region.of(region));
+
+        if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
+            // 로컬 환경
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+            ));
+        } else{
+            // 배포 환경
+            builder.credentialsProvider(DefaultCredentialsProvider.create());
+        }
+
+        return builder.build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(region));
+
+        if (!accessKey.isBlank() && !secretKey.isBlank()) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+            ));
+        } else {
+            builder.credentialsProvider(DefaultCredentialsProvider.create());
+        }
+        return builder.build();
+    }
+
+}

--- a/src/main/java/com/meetkey/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetkey/server/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui.html").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/s3/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/meetkey/server/global/s3/S3Controller.java
+++ b/src/main/java/com/meetkey/server/global/s3/S3Controller.java
@@ -1,0 +1,31 @@
+package com.meetkey.server.global.s3;
+
+import com.meetkey.server.global.apiPayload.response.BasicResponse;
+import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
+import com.meetkey.server.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/s3")
+public class S3Controller {
+    private final S3Service s3Service;
+
+    @Operation(summary = "업로드용 Presigned Url 발급 API", description = "프론트에서 파일 업로드 전에 요청")
+    @GetMapping("/presigned-upload")
+    public BasicResponse<S3ResDTO.PresignedUrl> getPresignedUploadUrl(
+            @RequestParam String folder,
+            @RequestParam String fileName,
+            @RequestParam String contentType
+    ){
+        S3ResDTO.PresignedUrl response = s3Service.generateUploadPresignedUrl(folder, fileName, contentType);
+        return BasicResponse.success(CommonSuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/com/meetkey/server/global/s3/S3ResDTO.java
+++ b/src/main/java/com/meetkey/server/global/s3/S3ResDTO.java
@@ -1,0 +1,11 @@
+package com.meetkey.server.global.s3;
+
+import lombok.Builder;
+
+public class S3ResDTO {
+    @Builder
+    public record PresignedUrl(
+            String url,
+            String key
+    ){}
+}

--- a/src/main/java/com/meetkey/server/global/s3/S3Service.java
+++ b/src/main/java/com/meetkey/server/global/s3/S3Service.java
@@ -1,0 +1,81 @@
+package com.meetkey.server.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    // S3에 이미지 업로드용 Presigned url 발급
+    public S3ResDTO.PresignedUrl generateUploadPresignedUrl(String folder, String originalFileName, String contentType){
+        String key = folder + "/" + UUID.randomUUID() +"-" + originalFileName;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(
+                r -> r.putObjectRequest(putObjectRequest)
+                        .signatureDuration(Duration.ofMinutes(5))
+        );
+
+        return S3ResDTO.PresignedUrl.builder()
+                .url(presignedPutObjectRequest.url().toString())
+                .key(key).build();
+    }
+
+    // S3 이미지 조회용 Presigned url 발급
+    public String generateGetPresignedUrl(String key){
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
+        return presignedGetObjectRequest.url().toString();
+    }
+
+    // s3에서 이미지 삭제
+    public void deleteFile(String imageUrl){
+        String key = extractKeyFromUrl(imageUrl);
+
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build()
+        );
+    }
+
+    // s3 url에서 key 추출
+    private String extractKeyFromUrl(String imageUrl){
+        int idx = imageUrl.indexOf(".amazonaws.com/") +  ".amazonaws.com/".length();
+        return imageUrl.substring(idx);
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,46 @@
+
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  jwt:
+    secret: ${JWT_SECRET_KEY:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+
+  application:
+    name: server
+
+  datasource:
+    url: ${DB_URL:}
+    username: ${DB_USERNAME:}
+    password: ${DB_PW:}
+    driver-class-name: ${DB_DRIVER:}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        format_sql: true
+
+coolsms:
+  api-key: ${COOLSMS_API_KEY:}
+  api-secret: ${COOLSMS_API_SECRET:}
+  sender: ${COOLSMS_SENDER:}
+
+admin:
+  secret: ${ADMIN_SECRET:1234}
+
+kakao:
+  app-key: ${KAKAO_APP_KEY:}
+
+apple:
+  app-key: ${APPLE_APP_KEY:}
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY:}
+      secret-key: ${AWS_SECRET_KEY:}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,39 @@
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  jwt:
+    secret: ${JWT_SECRET_KEY:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+
+  application:
+    name: server
+
+  datasource:
+    url: ${DB_URL:}
+    username: ${DB_USERNAME:}
+    password: ${DB_PW:}
+    driver-class-name: ${DB_DRIVER:}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        format_sql: true
+
+coolsms:
+  api-key: ${COOLSMS_API_KEY:}
+  api-secret: ${COOLSMS_API_SECRET:}
+  sender: ${COOLSMS_SENDER:}
+
+admin:
+  secret: ${ADMIN_SECRET:1234}
+
+kakao:
+  app-key: ${KAKAO_APP_KEY:}
+
+apple:
+  app-key: ${APPLE_APP_KEY:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,39 +1,10 @@
 spring:
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local} # 기본적으로 로컬 프로파일 활성화
 
-  jwt:
-    secret: ${JWT_SECRET_KEY:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
-
-  application:
-    name: server
-
-  datasource:
-    url: ${DB_URL:}
-    username: ${DB_USERNAME:}
-    password: ${DB_PW:}
-    driver-class-name: ${DB_DRIVER:}
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    properties:
-      hibernate:
-        format_sql: true
-
-coolsms:
-  api-key: ${COOLSMS_API_KEY:}
-  api-secret: ${COOLSMS_API_SECRET:}
-  sender: ${COOLSMS_SENDER:}
-
-admin:
-  secret: ${ADMIN_SECRET:1234}
-
-kakao:
-  app-key: ${KAKAO_APP_KEY:}
-
-apple:
-  app-key: ${APPLE_APP_KEY:}
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${S3_BUCKET:}


### PR DESCRIPTION
## 요약
- 스크린샷 첨부
<img width="1474" height="686" alt="image" src="https://github.com/user-attachments/assets/c685e4e9-56bd-4e28-a45b-1e859425a3b8" />
<img width="682" height="704" alt="image" src="https://github.com/user-attachments/assets/cac993b6-237c-4daf-b27f-05541a25f2c5" />

<br>
<br>

## 연결된 이슈 번호
- close #33 

<br>
<br>

## 세부 작업 사항
- s3 presigned url 을 GET 메소드로 발급받아서, url과 key를 받고, 그 url로 파일을 보내면 됩니다. 임의적으로 일단 구현해놔서 추후에 API 경로는 바뀔 수 있습니다.
- 각 도메인 별로 fileName을 나눠서 요청 보내면 좋을 것 같습니다. 

<br>
<br>

## Approve 하기 전에 확인할 것
- [ ] 로그인한 회원만 접근 가능하게 하려다가, 회원가입 완료 전에 프로필 사진이 등록될 수도 있어서 이 부분 논의해봐야할 것 같습니다. 
- [x] 배포 서버에서는 EC2에 IAM Role 권한 부여해서 하는 방식으로 해가지고 이게 잘되는지 확인해봐야 합니다. -> 잘되는 것 확인
- [ ]
- [ ]

<br>
<br>

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
