### PR TITLE
[REFACT/#36-login] 회원 가입/로그인 코드 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation 'com.h2database:h2'
 
     // redis

--- a/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
@@ -16,6 +16,8 @@ import com.meetkey.server.global.security.jwt.dto.JwtResDTO;
 import com.meetkey.server.global.security.oauth.dto.OauthReqDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -54,6 +56,10 @@ public class AuthController {
     }
 
     @Operation(summary = "로그인 API", description = "소셜 정보를 통해 로그인을 합니다. (애플 로그인의 경우 아직 작동 X)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = JwtResDTO.JwtResponse.class))),
+            @ApiResponse(responseCode = "400", description = "AUTH4003: 소셜 로그인 Provider 잘못 씀, AUTH4001: IdToken 파싱 과정 중 오류")
+    })
     @PostMapping("/login")
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> login(
             @RequestParam("provider") Provider provider,
@@ -65,6 +71,10 @@ public class AuthController {
     }
 
     @Operation(summary = "회원가입 API", description = "전화번호는 국제번호 규격에 맞추어야 합니다. ex: +821012345678")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = JwtResDTO.JwtResponse.class))),
+            @ApiResponse(responseCode = "400", description = "AUTH4003: 소셜 로그인 Provider 잘못 씀"),
+    })
     @PostMapping("/signup")
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> signup(
             @RequestParam("provider") Provider provider,
@@ -76,6 +86,10 @@ public class AuthController {
     }
 
     @Operation(summary = "토큰 재발급 API", description = "access 토큰 기간 만료 시 refresh 토큰으로 재발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = JwtResDTO.JwtResponse.class))),
+            @ApiResponse(responseCode = "401", description = "AUTH4011: 리프레시 토큰이 잘못됨")
+    })
     @PostMapping("/reissue")
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> reissue(
             @RequestHeader(value = "refresh", required = false) String refreshToken

--- a/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
@@ -16,6 +16,8 @@ import com.meetkey.server.global.security.jwt.dto.JwtResDTO;
 import com.meetkey.server.global.security.oauth.dto.OauthReqDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,7 +37,7 @@ public class AuthController {
     @Value("${admin.secret}")
     private String adminSecret;
 
-    @Operation(summary = "마스터 계정 발급")
+    @Operation(summary = "마스터 계정 발급", description = "노션에 마스터 토큰을 올려두었습니다. 이상 있는 경우 따밥/김채원 으로 연락주세요")
     @PostMapping("/test")
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> test(
             @RequestHeader(value = "X-Admin-Secret", required = false) String secret,

--- a/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/meetkey/server/domain/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import com.meetkey.server.global.security.jwt.dto.JwtResDTO;
 import com.meetkey.server.global.security.oauth.dto.OauthReqDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -38,7 +39,7 @@ public class AuthController {
     @PostMapping("/test")
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> test(
             @RequestHeader(value = "X-Admin-Secret", required = false) String secret,
-            @RequestBody OauthReqDTO.SignupReq signupReq
+            @Valid @RequestBody OauthReqDTO.SignupReq signupReq
     ) {
         if (adminSecret == null || !adminSecret.equals(secret)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
@@ -54,18 +55,18 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> login(
             @RequestParam("provider") Provider provider,
-            @RequestBody OauthReqDTO.LoginReq loginReq
+            @Valid @RequestBody OauthReqDTO.LoginReq loginReq
     ) {
         JwtResDTO.JwtResponse jwts = authService.login(provider, loginReq.idToken());
         return ResponseEntity.ok()
                 .body(BasicResponse.success(CommonSuccessStatus._OK, jwts));
     }
 
-    @Operation(summary = "회원가입 API", description = "소셜 로그인에 회원 정보가 없으면 회원가입을 합니다. (애플 로그인의 경우 아직 작동 X)")
+    @Operation(summary = "회원가입 API", description = "전화번호는 국제번호 규격에 맞추어야 합니다. ex: +821012345678")
     @PostMapping("/signup")
     public ResponseEntity<BasicResponse<JwtResDTO.JwtResponse>> signup(
             @RequestParam("provider") Provider provider,
-            @RequestBody OauthReqDTO.SignupReq signupReq
+            @Valid @RequestBody OauthReqDTO.SignupReq signupReq
     ) {
         JwtResDTO.JwtResponse jwts = authService.signup(provider, signupReq);
         return ResponseEntity.ok()

--- a/src/main/java/com/meetkey/server/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/meetkey/server/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,16 @@
+package com.meetkey.server.domain.auth.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+
+@Getter
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+    private String memberId;
+
+    public RefreshToken(final String refreshToken, final String memberId) {
+        this.refreshToken = refreshToken;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/meetkey/server/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,47 @@
+package com.meetkey.server.domain.auth.repository;
+
+import com.meetkey.server.domain.auth.entity.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+    private final StringRedisTemplate redisTemplate;
+    private static final String PREFIX = "refreshToken:";
+
+    public void save(final RefreshToken refreshToken) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String key = PREFIX + refreshToken.getRefreshToken();
+        valueOperations.set(
+                key,
+                String.valueOf(refreshToken.getMemberId()),
+                7,
+                TimeUnit.DAYS
+        );
+    }
+
+    public Optional<RefreshToken> findById(final String refreshToken){
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String memberId = valueOperations.get(PREFIX + refreshToken);
+
+        if (Objects.isNull(memberId)){
+            return Optional.empty();
+        }
+
+        return Optional.of(new RefreshToken(refreshToken,memberId));
+    }
+
+    public void delete(final String refreshToken) {
+        String key = PREFIX + refreshToken;
+
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/meetkey/server/domain/auth/repository/RefreshTokenRepository.java
@@ -28,6 +28,17 @@ public class RefreshTokenRepository {
         );
     }
 
+    public void saveDev(final RefreshToken refreshToken) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String key = PREFIX + refreshToken.getRefreshToken();
+        valueOperations.set(
+                key,
+                String.valueOf(refreshToken.getMemberId()),
+                365,
+                TimeUnit.DAYS
+        );
+    }
+
     public Optional<RefreshToken> findById(final String refreshToken){
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         String memberId = valueOperations.get(PREFIX + refreshToken);

--- a/src/main/java/com/meetkey/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/meetkey/server/domain/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.meetkey.server.domain.auth.service;
 
+import com.meetkey.server.domain.auth.entity.RefreshToken;
+import com.meetkey.server.domain.auth.repository.RefreshTokenRepository;
 import com.meetkey.server.domain.member.dto.MemberReqDTO;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.member.entity.SocialLogin;
@@ -39,9 +41,11 @@ public class AuthService {
     private final AppleOauthClient appleClient;
 
     private final OauthOidcHelper oAuthOIDCHelper;
-    private final SocialLoginRepository socialLoginRepository;
     private final JwtUtil jwtUtil;
     private final MemberService memberService;
+
+    private final SocialLoginRepository socialLoginRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public JwtResDTO.JwtResponse devSignup(OauthReqDTO.SignupReq req){
@@ -58,7 +62,6 @@ public class AuthService {
     @Transactional
     public JwtResDTO.JwtResponse signup(Provider provider, OauthReqDTO.SignupReq req){
         // 카카오 플랫폼 인증 및 ID 추출
-
         String providerId;
         if (provider == Provider.KAKAO) {
             providerId = getKakaoProviderIdFromIdToken(req.idToken());
@@ -79,7 +82,14 @@ public class AuthService {
 
     @Transactional
     public JwtResDTO.JwtResponse login(Provider provider, String idToken){
-        String providerId = getKakaoProviderIdFromIdToken(idToken);
+        String providerId;
+        if (provider == Provider.KAKAO) {
+            providerId = getKakaoProviderIdFromIdToken(idToken);
+        } else if (provider == Provider.APPLE) {
+            providerId = getAppleProviderIdFromIdToken(idToken);
+        } else {
+            throw new AuthException(AuthErrorStatus.INVALID_SOCIAL);
+        }
 
         Optional<SocialLogin> socialMember =
                 socialLoginRepository.findByProviderAndProviderId(provider, providerId);
@@ -100,21 +110,20 @@ public class AuthService {
 
     @Transactional
     public JwtResDTO.JwtResponse reissue(String refreshToken){
-        jwtUtil.validateRefreshToken(refreshToken);
+        jwtUtil.isValid(refreshToken, false);
 
-        if (!memberService.isRefreshTokenExists(refreshToken)) {
+        if (refreshTokenRepository.findById(refreshToken).isEmpty()) {
             throw new AuthException(AuthErrorStatus.INVALID_TOKEN);
         }
 
         String username = jwtUtil.getUsername(refreshToken);
         String role = jwtUtil.getRole(refreshToken);
 
+        String newAccess = jwtUtil.createJwt(username, role, true);
+        String newRefresh = jwtUtil.createJwt(username, role, false);
 
-        String newAccess = jwtUtil.createJwt(
-                "access", username, role, ACCESS_TOKEN_EXP);
-        String newRefresh = jwtUtil.createJwt("refresh", username, role, REFRESH_TOKEN_EXP);
-
-        memberService.updateRefreshToken(username, newRefresh);
+        refreshTokenRepository.delete(refreshToken);
+        refreshTokenRepository.save(new RefreshToken(newRefresh, username));
 
         return JwtResDTO.JwtResponse.builder()
                 .accessToken(newAccess)
@@ -125,10 +134,11 @@ public class AuthService {
     }
 
     private JwtResDTO.JwtResponse getJwtResponseDTO(Member member) {
-        String accessToken = jwtUtil.createJwt("access", member.getId().toString(), member.getRole().toString(), ACCESS_TOKEN_EXP);
-        String refreshToken = jwtUtil.createJwt("refresh", member.getId().toString(), member.getRole().toString(), REFRESH_TOKEN_EXP);
+        String accessToken = jwtUtil.createJwt(member.getId().toString(), member.getRole().toString(), true);
+        String refreshToken = jwtUtil.createJwt(member.getId().toString(), member.getRole().toString(), false);
 
-        member.changeRefreshToken(refreshToken, REFRESH_TOKEN_EXP);
+        // redis에 refreshtoken 저장
+        refreshTokenRepository.save(new RefreshToken(refreshToken, member.getId().toString()));
 
         return JwtResDTO.JwtResponse.builder()
                 .memberId(member.getId())
@@ -139,10 +149,11 @@ public class AuthService {
     }
 
     private JwtResDTO.JwtResponse getDevJwtResponseDTO(Member member) {
-        String accessToken = jwtUtil.createJwt("access", member.getId().toString(), member.getRole().toString(), 1000 * 60 * 60 * 24 * 365L);
-        String refreshToken = jwtUtil.createJwt("refresh", member.getId().toString(), member.getRole().toString(), 1000 * 60 * 60 * 24 * 3650L);
+        String accessToken = jwtUtil.createDevJwt(member.getId().toString(), member.getRole().toString(), true);
+        String refreshToken = jwtUtil.createDevJwt(member.getId().toString(), member.getRole().toString(), false);
 
-        member.changeRefreshToken(refreshToken, REFRESH_TOKEN_EXP);
+        // redis에 refreshtoken 저장
+        refreshTokenRepository.save(new RefreshToken(refreshToken, member.getId().toString()));
 
         return JwtResDTO.JwtResponse.builder()
                 .memberId(member.getId())

--- a/src/main/java/com/meetkey/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/meetkey/server/domain/auth/service/AuthService.java
@@ -29,8 +29,6 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private static final Long ACCESS_TOKEN_EXP = 600000L; // 10분
-    private static final Long REFRESH_TOKEN_EXP = 86400000L; // 24시간
 
     @Value("${kakao.app-key}")
     private String kakaoAppKey;
@@ -152,8 +150,8 @@ public class AuthService {
         String accessToken = jwtUtil.createDevJwt(member.getId().toString(), member.getRole().toString(), true);
         String refreshToken = jwtUtil.createDevJwt(member.getId().toString(), member.getRole().toString(), false);
 
-        // redis에 refreshtoken 저장
-        refreshTokenRepository.save(new RefreshToken(refreshToken, member.getId().toString()));
+        // redis에 refreshToken 저장
+        refreshTokenRepository.saveDev(new RefreshToken(refreshToken, member.getId().toString()));
 
         return JwtResDTO.JwtResponse.builder()
                 .memberId(member.getId())

--- a/src/main/java/com/meetkey/server/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/member/dto/MemberReqDTO.java
@@ -2,6 +2,7 @@ package com.meetkey.server.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.meetkey.server.domain.member.enums.*;
+import com.meetkey.server.global.annotation.PhoneNumber;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -19,6 +20,6 @@ public class MemberReqDTO {
             @NotNull Language firstLanguage,
             @NotNull Language targetLanguage,
             @NotNull Level targetLanguageLevel,
-            @NotNull String phoneNumber
+            @NotNull @PhoneNumber String phoneNumber
     ){}
 }

--- a/src/main/java/com/meetkey/server/domain/member/entity/Member.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/Member.java
@@ -73,26 +73,12 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private Integer notRecommendCount = 0;
-
-
-
-
-
-    private String refreshToken;
-    private LocalDateTime refreshTokenExpiration;
-
     /*
      * 관심사
      */
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<InterestMember> interestMembers = new ArrayList<>();
-
-
-    public void changeRefreshToken(String newRefreshToken, Long expMillis) {
-        this.refreshToken = newRefreshToken;
-        this.refreshTokenExpiration = LocalDateTime.now().plusNanos(expMillis);
-    }
 
     // 프로필 업데이트
     public void updateProfileInfo(String location, String bio, Language first, Language target, Level level) {

--- a/src/main/java/com/meetkey/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/meetkey/server/domain/member/repository/MemberRepository.java
@@ -6,6 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
-    Boolean existsByRefreshToken(String refreshToken);
-    Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
@@ -56,7 +56,7 @@ public class MemberService {
                 .firstLanguage(req.firstLanguage())
                 .homeTown(req.homeTown())
                 .targetLanguageLevel(req.targetLanguageLevel())
-                .role(Role.valueOf("ROLE_ADMIN"))
+                .role(Role.ROLE_ADMIN)
                 .build();
 
         memberRepository.save(member);
@@ -69,23 +69,5 @@ public class MemberService {
         socialLoginRepository.save(socialMember);
 
         return member;
-    }
-
-    @Transactional
-    public void updateRefreshToken(String username, String newRefresh) {
-        Long memberId = Long.parseLong(username);
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
-
-        if (newRefresh != null) {
-            member.changeRefreshToken(newRefresh, 86400000L);
-        } else {
-            member.changeRefreshToken(null,0L);
-        }
-    }
-
-    public boolean isRefreshTokenExists(String refreshToken){
-        return memberRepository.existsByRefreshToken(refreshToken);
     }
 }

--- a/src/main/java/com/meetkey/server/domain/report/controller/ReportController.java
+++ b/src/main/java/com/meetkey/server/domain/report/controller/ReportController.java
@@ -1,0 +1,29 @@
+package com.meetkey.server.domain.report.controller;
+
+import com.meetkey.server.domain.report.dto.ReportReqDTO;
+import com.meetkey.server.domain.report.service.ReportService;
+import com.meetkey.server.global.apiPayload.response.BasicResponse;
+import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
+import com.meetkey.server.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/report")
+public class ReportController {
+    private final ReportService reportService;
+
+    @PostMapping("/{targetId}")
+    public ResponseEntity<BasicResponse<Void>> createReport(
+            @AuthenticationPrincipal CustomUserDetails reporter,
+            @PathVariable Long targetId,
+            @RequestBody ReportReqDTO.CreateReport req
+    ) {
+        reportService.createReport(reporter.getMemberId(), targetId, req);
+        return ResponseEntity.ok()
+                .body(BasicResponse.success(CommonSuccessStatus._OK, null));
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/report/dto/ReportReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/report/dto/ReportReqDTO.java
@@ -1,0 +1,15 @@
+package com.meetkey.server.domain.report.dto;
+
+import com.meetkey.server.domain.report.enums.ReportType;
+import lombok.Builder;
+
+import java.util.List;
+
+public class ReportReqDTO {
+    @Builder
+    public record CreateReport (
+            ReportType reportType,
+            String body,
+            List<String> imageUrls
+    ){}
+}

--- a/src/main/java/com/meetkey/server/domain/report/entity/mapping/ReportHistory.java
+++ b/src/main/java/com/meetkey/server/domain/report/entity/mapping/ReportHistory.java
@@ -22,14 +22,14 @@ public class ReportHistory {
     @ManyToOne(fetch = FetchType.LAZY)
     private Report report;
 
-    @Column(nullable = false)
     private String managerId;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private ReportStatus status;
+    @Builder.Default
+    private ReportStatus status = ReportStatus.PENDING;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String reason;
 
     private LocalDateTime suspendedAt;

--- a/src/main/java/com/meetkey/server/domain/report/entity/mapping/ReportPhoto.java
+++ b/src/main/java/com/meetkey/server/domain/report/entity/mapping/ReportPhoto.java
@@ -2,13 +2,11 @@ package com.meetkey.server.domain.report.entity.mapping;
 
 import com.meetkey.server.domain.report.entity.Report;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "report_photo")

--- a/src/main/java/com/meetkey/server/domain/report/repository/ReportHistoryRepository.java
+++ b/src/main/java/com/meetkey/server/domain/report/repository/ReportHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.meetkey.server.domain.report.repository;
+
+import com.meetkey.server.domain.report.entity.mapping.ReportHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportHistoryRepository extends JpaRepository<ReportHistory, Long> {
+}

--- a/src/main/java/com/meetkey/server/domain/report/repository/ReportPhotoRepository.java
+++ b/src/main/java/com/meetkey/server/domain/report/repository/ReportPhotoRepository.java
@@ -1,0 +1,7 @@
+package com.meetkey.server.domain.report.repository;
+
+import com.meetkey.server.domain.report.entity.mapping.ReportPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportPhotoRepository extends JpaRepository<ReportPhoto, Long> {
+}

--- a/src/main/java/com/meetkey/server/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/meetkey/server/domain/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.meetkey.server.domain.report.repository;
+
+import com.meetkey.server.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/meetkey/server/domain/report/service/ReportService.java
+++ b/src/main/java/com/meetkey/server/domain/report/service/ReportService.java
@@ -1,0 +1,71 @@
+package com.meetkey.server.domain.report.service;
+
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.exception.MemberErrorStatus;
+import com.meetkey.server.domain.member.exception.MemberException;
+import com.meetkey.server.domain.member.repository.MemberRepository;
+import com.meetkey.server.domain.report.dto.ReportReqDTO;
+import com.meetkey.server.domain.report.entity.Report;
+import com.meetkey.server.domain.report.entity.mapping.ReportHistory;
+import com.meetkey.server.domain.report.entity.mapping.ReportPhoto;
+import com.meetkey.server.domain.report.repository.ReportHistoryRepository;
+import com.meetkey.server.domain.report.repository.ReportPhotoRepository;
+import com.meetkey.server.domain.report.repository.ReportRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ReportService {
+
+    private final MemberRepository memberRepository;
+    private final ReportRepository reportRepository;
+    private final ReportPhotoRepository reportPhotoRepository;
+    private final ReportHistoryRepository reportHistoryRepository;
+
+    public ReportService(MemberRepository memberRepository, ReportRepository reportRepository, ReportPhotoRepository reportPhotoRepository, ReportHistoryRepository reportHistoryRepository) {
+        this.memberRepository = memberRepository;
+        this.reportRepository = reportRepository;
+        this.reportPhotoRepository = reportPhotoRepository;
+        this.reportHistoryRepository = reportHistoryRepository;
+    }
+
+    @Transactional
+    public void createReport(Long reporterId, Long targetId, ReportReqDTO.CreateReport req){
+        Member reporterMember = memberRepository.findById(reporterId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        Member targetMember = memberRepository.findById(targetId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        // report에 저장
+        Report report = Report.builder()
+                .reporterMember(reporterMember)
+                .reportedMember(targetMember)
+                .reportType(req.reportType())
+                .body(req.body())
+                .build();
+
+        reportRepository.save(report);
+
+        // 사진을 reportPhoto에 저장
+        if (req.imageUrls() != null) {
+            for (String url : req.imageUrls()) {
+                ReportPhoto photo = ReportPhoto.builder()
+                        .report(report)
+                        .reportPhotoUrl(url)
+                        .build();
+
+                reportPhotoRepository.save(photo);
+            }
+        }
+
+        // reportHistory에 status를 Pending으로 한 채로 저장
+        ReportHistory history = ReportHistory.builder()
+                .report(report)
+                .build();
+
+        reportHistoryRepository.save(history);
+    }
+}

--- a/src/main/java/com/meetkey/server/global/annotation/PhoneNumber.java
+++ b/src/main/java/com/meetkey/server/global/annotation/PhoneNumber.java
@@ -1,0 +1,17 @@
+package com.meetkey.server.global.annotation;
+
+import com.meetkey.server.global.validator.PhoneNumberValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PhoneNumberValidator.class)
+@Target( {ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PhoneNumber {
+    String message() default "휴대전화 번호가 국제번호 규격에 맞지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/meetkey/server/global/annotation/PhoneNumber.java
+++ b/src/main/java/com/meetkey/server/global/annotation/PhoneNumber.java
@@ -1,0 +1,17 @@
+package com.meetkey.server.global.annotation;
+
+import com.meetkey.server.global.validator.PhoneNumberValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PhoneNumberValidator.class)
+@Target( {ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PhoneNumber {
+    String message() default "휴대전화 번호가 국제번호 규격에 맞지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/meetkey/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetkey/server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.global.config;
 
+import com.meetkey.server.domain.auth.repository.RefreshTokenRepository;
 import com.meetkey.server.domain.member.service.MemberService;
 import com.meetkey.server.global.security.jwt.JwtUtil;
 import com.meetkey.server.global.security.jwt.filter.CustomLogoutFilter;
@@ -15,8 +16,15 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public SecurityConfig(JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository) {
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtUtil jwtUtil, MemberService memberService) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -24,7 +32,7 @@ public class SecurityConfig {
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new CustomLogoutFilter(jwtUtil, memberService), LogoutFilter.class)
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshTokenRepository), LogoutFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()

--- a/src/main/java/com/meetkey/server/global/config/SmsConfig.java
+++ b/src/main/java/com/meetkey/server/global/config/SmsConfig.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class SmsConfig {
+public class    SmsConfig {
 
     @Value("${coolsms.api-key}")
     private String apiKey;

--- a/src/main/java/com/meetkey/server/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/meetkey/server/global/security/jwt/JwtUtil.java
@@ -1,11 +1,9 @@
 package com.meetkey.server.global.security.jwt;
 
 
-import com.meetkey.server.domain.auth.exception.AuthErrorStatus;
-import com.meetkey.server.domain.auth.exception.AuthException;
-import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +15,8 @@ import java.util.Date;
 @Component
 public class JwtUtil {
     private final SecretKey secretKey;
+    private final Long accessTokenExpiresIn = 3600L * 1000; // 1시간
+    private final Long refreshTokenExpiresIn = 604800L * 1000; // 7일
 
     public JwtUtil(@Value("${spring.jwt.secret}")String secret ) {
         secretKey = new SecretKeySpec(
@@ -25,70 +25,66 @@ public class JwtUtil {
         );
     }
 
-    public String getCategory(String token){
-        return Jwts.parser().verifyWith(secretKey).build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .get("category", String.class);
-    }
-
     public String getUsername(String token) {
         return Jwts.parser().verifyWith(secretKey).build()
                 .parseSignedClaims(token)
-                .getPayload()
-                .getSubject();
+                .getPayload().get("sub", String.class);
     }
 
     public String getRole(String token) {
         return Jwts.parser().verifyWith(secretKey).build()
                 .parseSignedClaims(token)
-                .getPayload()
-                .get("role", String.class);
+                .getPayload().get("role", String.class);
     }
 
-    public Boolean isExpired(String token) {
-        return Jwts.parser().verifyWith(secretKey).build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .getExpiration().before(new Date());
+    public Boolean isValid(String token, Boolean isAccess) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            String type = claims.get("type", String.class);
+            if (type == null) return false;
+
+            if (isAccess && !type.equals("access")) return false;
+            if (!isAccess && !type.equals("refresh")) return false;
+
+            return true;
+
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
 
-    public String createJwt(String category, String username, String role, Long expiredMs){
+    public String createJwt(String username, String role, Boolean isAccess) {
+        long now = System.currentTimeMillis();
+        long expiry = isAccess ? accessTokenExpiresIn : refreshTokenExpiresIn;
+        String type = isAccess ? "access" : "refresh";
+
         return Jwts.builder()
-                .subject(username)
-                .claim("category", category)
+                .claim("sub", username)
                 .claim("role", role)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .claim("type", type)
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + expiry))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public Cookie createCookie(String key, String value){
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(24*60*60);
-        cookie.setHttpOnly(true);
+    public String createDevJwt(String username, String role, Boolean isAccess) {
+        long now = System.currentTimeMillis();
+        long expiry = isAccess ? 604800L * 10000 : 604800L * 100000;
+        String type = isAccess ? "access" : "refresh";
 
-        return cookie;
-    }
-
-    public void validateRefreshToken(String refreshToken) {
-        if (refreshToken == null) {
-            throw new AuthException(AuthErrorStatus.INVALID_TOKEN);
-        }
-
-        // refresh token 토큰 만료 검증
-        try {
-            this.isExpired(refreshToken);
-        } catch (ExpiredJwtException e) {
-            throw new AuthException(AuthErrorStatus.EXPIRED_TOKEN);
-        }
-
-        // 토큰이 refresh인지 확인
-        String category = this.getCategory(refreshToken);
-
-        if (!category.equals("refresh")){
-            throw new  AuthException(AuthErrorStatus.INVALID_TOKEN);
-        }
+        return Jwts.builder()
+                .claim("sub", username)
+                .claim("role", role)
+                .claim("type", type)
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + expiry))
+                .signWith(secretKey)
+                .compact();
     }
 }

--- a/src/main/java/com/meetkey/server/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/meetkey/server/global/security/jwt/JwtUtil.java
@@ -74,8 +74,9 @@ public class JwtUtil {
     }
 
     public String createDevJwt(String username, String role, Boolean isAccess) {
+        long oneDay = 1;
         long now = System.currentTimeMillis();
-        long expiry = isAccess ? 604800L * 10000 : 604800L * 100000;
+        long expiry = isAccess ? oneDay * 365 : oneDay * 3650;
         String type = isAccess ? "access" : "refresh";
 
         return Jwts.builder()

--- a/src/main/java/com/meetkey/server/global/security/jwt/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/meetkey/server/global/security/jwt/filter/CustomLogoutFilter.java
@@ -1,6 +1,7 @@
 package com.meetkey.server.global.security.jwt.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetkey.server.domain.auth.repository.RefreshTokenRepository;
 import com.meetkey.server.domain.member.service.MemberService;
 import com.meetkey.server.global.apiPayload.response.BasicResponse;
 import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
@@ -21,7 +22,7 @@ import java.io.PrintWriter;
 @RequiredArgsConstructor
 public class CustomLogoutFilter extends GenericFilterBean {
     private final JwtUtil jwtUtil;
-    private final MemberService memberService;
+    private final RefreshTokenRepository  refreshTokenRepository;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
@@ -49,27 +50,18 @@ public class CustomLogoutFilter extends GenericFilterBean {
         }
 
         try {
-            jwtUtil.isExpired(refresh);
+            jwtUtil.isValid(refresh, false);
         } catch (ExpiredJwtException e){
             anywayLogout(response);
             return;
         }
 
-        String category = jwtUtil.getCategory(refresh);
-        if (!category.equals("refresh")) {
-
-            //response status code
+        if (refreshTokenRepository.findById(refresh).isEmpty()){
             anywayLogout(response);
             return;
         }
 
-        if (!memberService.isRefreshTokenExists(refresh)){
-            anywayLogout(response);
-            return;
-        }
-
-        String username = jwtUtil.getUsername(refresh);
-        memberService.updateRefreshToken(username, null);
+        refreshTokenRepository.delete(refresh);
 
         anywayLogout(response);
     }

--- a/src/main/java/com/meetkey/server/global/security/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/meetkey/server/global/security/jwt/filter/JwtFilter.java
@@ -5,7 +5,6 @@ import com.meetkey.server.domain.auth.exception.AuthErrorStatus;
 import com.meetkey.server.global.apiPayload.response.BasicResponse;
 import com.meetkey.server.global.security.CustomUserDetails;
 import com.meetkey.server.global.security.jwt.JwtUtil;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,13 +32,23 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        String accessToken = authorization.substring(7);
-
+        String accessToken = authorization.split(" ")[1];
         // 토큰 만료 여부 확인, 만료 시 다음 필터로 넘기지 않는다.
-        try {
-            jwtUtil.isExpired(accessToken);
-        } catch (JwtException e) {
-            // response status code
+        if (jwtUtil.isValid(accessToken, true)){
+
+            String username = jwtUtil.getUsername(accessToken); // memberId
+            String role = jwtUtil.getRole(accessToken);
+
+            // 임시 인증 객체
+            CustomUserDetails customUserDetails = new CustomUserDetails(username, role);
+
+            Authentication authToken = new UsernamePasswordAuthenticationToken(
+                    customUserDetails, null, customUserDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+
+            filterChain.doFilter(request, response);
+        } else {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
             response.setContentType("application/json;charset=UTF-8");
@@ -53,35 +62,7 @@ public class JwtFilter extends OncePerRequestFilter {
             writer.write(json);
             writer.flush();
             writer.close();
-
-            return;
         }
 
-        // 토큰이 access 인지 확인
-        String category = jwtUtil.getCategory(accessToken);
-
-        if (!category.equals("access")){
-            //response body
-            PrintWriter writer = response.getWriter();
-            writer.print("invalid access token");
-
-            //response status code
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            return;
-        }
-
-        String username = jwtUtil.getUsername(accessToken);
-        String role = jwtUtil.getRole(accessToken);
-
-        // 임시 인증 객체
-        CustomUserDetails customUserDetails =
-                new CustomUserDetails(username, role);
-
-        Authentication authToken = new UsernamePasswordAuthenticationToken(
-                customUserDetails, null, customUserDetails.getAuthorities());
-
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-
-        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/meetkey/server/global/security/oauth/dto/OauthReqDTO.java
+++ b/src/main/java/com/meetkey/server/global/security/oauth/dto/OauthReqDTO.java
@@ -2,6 +2,7 @@ package com.meetkey.server.global.security.oauth.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.meetkey.server.domain.member.enums.*;
+import com.meetkey.server.global.annotation.PhoneNumber;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
@@ -23,6 +24,6 @@ public class OauthReqDTO {
             @NotNull Language targetLanguage,
             @NotNull Level targetLanguageLevel,
 
-            @NotNull String phoneNumber
+            @NotNull @PhoneNumber String phoneNumber
     ){}
 }

--- a/src/main/java/com/meetkey/server/global/validator/PhoneNumberValidator.java
+++ b/src/main/java/com/meetkey/server/global/validator/PhoneNumberValidator.java
@@ -1,0 +1,13 @@
+package com.meetkey.server.global.validator;
+
+import com.meetkey.server.global.annotation.PhoneNumber;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PhoneNumberValidator implements ConstraintValidator<PhoneNumber, String> {
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        return s.matches("^\\+[1-9]\\d{1,14}$"); // 국제 번호 규격
+    }
+}


### PR DESCRIPTION
## 연결된 이슈 번호
- close #36 

<br>
<br>

## 세부 작업 사항
- 기존의 Refresh 토큰을 Member 테이블에 저장해두는 방식에서, Redis에 저장하는 방식으로 변경하였습니다.
- 추가적으로 빠뜨렸던 회원 차단 구현도 했습니다.


<br>
<br>

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
