### PR TITLE
[FEAT] 알림 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build
 !**/src/test/**/build/
 
 /src/main/resources/application-secret.yml
+
+# firebase service account keys
+src/main/resources/firebase/*.json

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+    // Firebase Admin SDK
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
 }
 
 ext {

--- a/src/main/java/com/meetkey/server/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/meetkey/server/domain/chat/controller/ChatController.java
@@ -8,12 +8,19 @@ import com.meetkey.server.global.apiPayload.response.BasicResponse;
 import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
 import com.meetkey.server.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static com.meetkey.server.domain.chat.dto.request.ChatReqDTO.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,7 +34,7 @@ public class ChatController {
     @Operation(summary = "채팅방 생성 API", description = "새로운 채팅방을 생성합니다. 상대방 ID 등을 전달받아 방을 개설합니다.")
     @PostMapping
     public BasicResponse<ChatResDTO.CreateChatRoomRes> createChatRoom(
-            @RequestBody ChatReqDTO.CreateChatRoomReq req
+            @RequestBody CreateChatRoomReq req
             ,@AuthenticationPrincipal CustomUserDetails details
     ){
         ChatResDTO.CreateChatRoomRes chatRoom = chatCommandService.createChatRoom(req, details.getMemberId());
@@ -72,5 +79,21 @@ public class ChatController {
     ) {
         chatCommandService.readMessages(details.getMemberId(), chatRoomId);
         return BasicResponse.success(CommonSuccessStatus._OK, null);
+    }
+
+    @Operation(summary = "채팅방 알림 설정 변경 API", description = "특정 채팅방의 알림 설정을 켜거나 끕니다. (true : 켜기, false : 끄기)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "400", description = "MEMBER4041: 사용자를 찾을 수 없음, CHAT2041 : 채팅방을 찾을 수 없음, CHAT2043 : 채팅방 멤버를 찾을 수 없음")
+    })
+    @PatchMapping("/{chatRoomId}/alarm")
+    public BasicResponse<String> updateChatAlarm(
+            @Parameter(description = "채팅방 ID", example = "1") @PathVariable Long chatRoomId,
+            @RequestBody ChatAlarmReq request,
+            @AuthenticationPrincipal CustomUserDetails details
+    ) {
+        chatCommandService.toggleAlarm(details.getMemberId(), chatRoomId, request.isAlarm());
+        String message = request.isAlarm() ? "채팅 알림이 켜졌습니다." : "채팅 알림이 꺼졌습니다.";
+        return BasicResponse.success(CommonSuccessStatus._OK, message);
     }
 }

--- a/src/main/java/com/meetkey/server/domain/chat/dto/request/ChatReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/chat/dto/request/ChatReqDTO.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.domain.chat.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public class ChatReqDTO {
@@ -8,4 +9,9 @@ public class ChatReqDTO {
             @NotNull
             Long targetUserId
     ){}
+
+    public record ChatAlarmReq(
+            @Schema(description = "알림 켜기(true) / 끄기(false)", example = "false")
+            boolean isAlarm
+    ) {}
 }

--- a/src/main/java/com/meetkey/server/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/meetkey/server/domain/chat/entity/ChatRoomMember.java
@@ -37,6 +37,9 @@ public class ChatRoomMember extends BaseEntity{
 
     private LocalDateTime joinedAt;
 
+    @Column(nullable = false)
+    private boolean isAlarm = true;
+
     public void updateLastReadMsg(ChatMessage lastReadMsg){
         if (this.lastReadMsg != null &&
                 this.lastReadMsg.getId() >= lastReadMsg.getId()) {
@@ -44,5 +47,9 @@ public class ChatRoomMember extends BaseEntity{
         }
 
         this.lastReadMsg = lastReadMsg;
+    }
+
+    public void toggleAlarm(boolean isAlarm) {
+        this.isAlarm = isAlarm;
     }
 }

--- a/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
@@ -45,4 +45,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     """)
     List<Long> findMemberIdsByChatRoomId(Long chatRoomId);
 
+    // 채팅방 멤버 조회 (멤버ID, 채팅방ID)
+    Optional<ChatRoomMember> findByMemberIdAndChatRoomId(Long memberId, Long chatRoomId);
+
 }

--- a/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
@@ -45,7 +45,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     """)
     List<Long> findMemberIdsByChatRoomId(Long chatRoomId);
 
-    // 채팅방 멤버 조회 (멤버ID, 채팅방ID)
-    Optional<ChatRoomMember> findByMemberIdAndChatRoomId(Long memberId, Long chatRoomId);
+    // 채팅방 멤버 조회 (채팅방ID)
+    List<ChatRoomMember> findAllByChatRoomId(Long chatRoomId);
 
 }

--- a/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
@@ -5,6 +5,7 @@ import com.meetkey.server.domain.chat.entity.ChatRoomMember;
 import com.meetkey.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -47,5 +48,8 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     // 채팅방 멤버 조회 (채팅방ID)
     List<ChatRoomMember> findAllByChatRoomId(Long chatRoomId);
+
+    @Query("SELECT cm.member FROM ChatRoomMember cm WHERE cm.chatRoom.id = :roomId AND cm.member.id != :myId")
+    Optional<Member> findPartner(@Param("roomId") Long roomId, @Param("myId") Long myId);
 
 }

--- a/src/main/java/com/meetkey/server/domain/chat/service/command/ChatCommandService.java
+++ b/src/main/java/com/meetkey/server/domain/chat/service/command/ChatCommandService.java
@@ -96,4 +96,19 @@ public class ChatCommandService {
         return (a < b) ? a + ":" + b : b + ":" + a;
     }
 
+    // 채팅방 알림 설정/해제 (토글)
+    public void toggleAlarm(Long memberId, Long chatRoomId, boolean isAlarm) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new ChatException(ChatErrorStatus.CHAT_ROOM_NOT_FOUND));
+
+        ChatRoomMember myChatRoomMember =
+                chatRoomMemberRepository.findByMemberAndChatRoom(member, chatRoom)
+                        .orElseThrow(() -> new ChatException(ChatErrorStatus.CHAT_ROOM_MEMBER_NOT_FOUND));
+
+        myChatRoomMember.toggleAlarm(isAlarm);
+    }
+
 }

--- a/src/main/java/com/meetkey/server/domain/chat/service/command/ChatCommandService.java
+++ b/src/main/java/com/meetkey/server/domain/chat/service/command/ChatCommandService.java
@@ -15,6 +15,7 @@ import com.meetkey.server.domain.member.exception.MemberErrorStatus;
 import com.meetkey.server.domain.member.exception.MemberException;
 import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.domain.chat.exception.ChatException;
+import com.meetkey.server.domain.notification.service.NotificationService;
 import com.meetkey.server.global.apiPayload.exception.GeneralException;
 import com.meetkey.server.global.apiPayload.status.CommonErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class ChatCommandService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
 
     // 채팅방 생성
     public ChatResDTO.CreateChatRoomRes createChatRoom(ChatReqDTO.CreateChatRoomReq req, Long memberId){
@@ -79,6 +81,13 @@ public class ChatCommandService {
         ChatRoomMember myChatRoomMember =
                 chatRoomMemberRepository.findByMemberAndChatRoom(member, chatRoom)
                         .orElseThrow(() -> new ChatException(ChatErrorStatus.CHAT_ROOM_MEMBER_NOT_FOUND));
+
+        // 알림 로직 -> 상대방이 보낸 알림들 읽음 처리
+        Member partner = chatRoomMemberRepository.findPartner(chatRoomId, memberId)
+                .orElse(null);
+        if (partner != null) {
+            notificationService.readNotificationBySender(member, partner);
+        }
 
         // 채팅방의 가장 최신 메시지 조회
         ChatMessage latestMessage = chatMessageRepository.findTop1ByChatRoomOrderByIdDesc(chatRoom).orElse(null);

--- a/src/main/java/com/meetkey/server/domain/chat/service/command/ChatMessageCommandService.java
+++ b/src/main/java/com/meetkey/server/domain/chat/service/command/ChatMessageCommandService.java
@@ -2,6 +2,7 @@ package com.meetkey.server.domain.chat.service.command;
 
 import com.meetkey.server.domain.chat.entity.ChatMessage;
 import com.meetkey.server.domain.chat.entity.ChatRoom;
+import com.meetkey.server.domain.chat.entity.ChatRoomMember;
 import com.meetkey.server.domain.chat.entity.enums.MessageType;
 import com.meetkey.server.domain.chat.exception.ChatErrorStatus;
 import com.meetkey.server.domain.chat.exception.ChatMessageException;
@@ -10,9 +11,13 @@ import com.meetkey.server.domain.chat.repository.ChatRoomMemberRepository;
 import com.meetkey.server.domain.chat.repository.ChatRoomRepository;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.member.repository.MemberRepository;
+import com.meetkey.server.domain.notification.enums.NotificationType;
+import com.meetkey.server.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +28,8 @@ public class ChatMessageCommandService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final MemberRepository memberRepository;
+
+    private final NotificationService notificationService;
 
     public ChatMessage sendMessage(Long senderId, Long chatRoomId, MessageType messageType, String content, String mediaUrl, Integer duration) {
 
@@ -52,6 +59,34 @@ public class ChatMessageCommandService {
                 .duration(resolvedDuration)
                 .build();
 
-        return chatMessageRepository.save(message);
+        ChatMessage savedMessage = chatMessageRepository.save(message);
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findAllByChatRoomId(chatRoomId);
+        for (ChatRoomMember target : members) {
+//            if (target.getMember().getId().equals(senderId)) continue; // 본인 제외
+
+            // 알림을 끈 사람은 제외
+            if (!target.isAlarm()) continue;
+
+            String notificationContent = getNotificationContent(messageType, content);
+
+            notificationService.sendNotification(
+                    sender,
+                    target.getMember(),
+                    NotificationType.MESSAGE,
+                    notificationContent,
+                    savedMessage
+            );
+        }
+
+        return savedMessage;
+    }
+
+    private String getNotificationContent(MessageType type, String content) {
+        return switch (type) {
+            case TEXT -> content;
+            case IMAGE -> "사진을 보냈습니다.";
+            case VOICE -> "음성 메시지를 보냈습니다.";
+        };
     }
 }

--- a/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
@@ -1,0 +1,44 @@
+package com.meetkey.server.domain.member.controller;
+
+import com.meetkey.server.domain.member.dto.MemberReqDTO;
+import com.meetkey.server.domain.member.dto.ProfileResDTO;
+import com.meetkey.server.domain.member.service.MemberService;
+import com.meetkey.server.global.apiPayload.response.BasicResponse;
+import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
+import com.meetkey.server.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.meetkey.server.domain.member.dto.MemberReqDTO.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "FCM 토큰 저장 API", description = "사용자의 FCM 토큰을 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = String.class ))),
+            @ApiResponse(responseCode = "400", description = "MEMBER4041: 해당 사용자를 찾을 수 없습니다.")
+    })
+    @PostMapping("/fcm-token")
+    public ResponseEntity<BasicResponse<String>> saveFcmToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody FcmTokenReq request
+    ) {
+        memberService.saveFcmToken(userDetails.getMemberId(), request.token());
+        return ResponseEntity.ok(BasicResponse.success(CommonSuccessStatus._OK, "토큰 저장 완료"));
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
@@ -28,7 +28,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "FCM 토큰 저장 API", description = "사용자의 FCM 토큰을 저장합니다.")
+    @Operation(summary = "FCM 토큰 저장 API", description = "사용자의 FCM 토큰을 저장합니다. (앱이 켜지거나 로그인시에 호출)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = String.class ))),
             @ApiResponse(responseCode = "400", description = "MEMBER4041: 해당 사용자를 찾을 수 없습니다.")

--- a/src/main/java/com/meetkey/server/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/meetkey/server/domain/member/dto/MemberReqDTO.java
@@ -3,6 +3,7 @@ package com.meetkey.server.domain.member.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.meetkey.server.domain.member.enums.*;
 import com.meetkey.server.global.annotation.PhoneNumber;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -22,4 +23,9 @@ public class MemberReqDTO {
             @NotNull Level targetLanguageLevel,
             @NotNull @PhoneNumber String phoneNumber
     ){}
+
+    public record FcmTokenReq(
+            @Schema(description = "FCM 토큰", example = "fcm_token_example_123456")
+            String token
+    ) {}
 }

--- a/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
@@ -4,12 +4,14 @@ package com.meetkey.server.domain.member.service;
 import com.meetkey.server.domain.member.dto.MemberReqDTO;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.member.entity.SocialLogin;
+import com.meetkey.server.domain.member.entity.mapping.FcmToken;
 import com.meetkey.server.domain.member.enums.Provider;
 import com.meetkey.server.domain.member.enums.Role;
 import com.meetkey.server.domain.member.exception.MemberErrorStatus;
 import com.meetkey.server.domain.member.exception.MemberException;
 import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.domain.member.repository.SocialLoginRepository;
+import com.meetkey.server.domain.notification.repository.FcmTokenRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final SocialLoginRepository socialLoginRepository;
+    private final FcmTokenRepository fcmTokenRepository;
 
     @Transactional
     public Member signup(Provider provider, String providerId, MemberReqDTO.Signup req) {
@@ -69,5 +72,21 @@ public class MemberService {
         socialLoginRepository.save(socialMember);
 
         return member;
+    }
+
+    // FCM 토큰 저장
+    @Transactional
+    public void saveFcmToken(Long memberId, String token) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        boolean isExist = fcmTokenRepository.existsByMemberAndToken(member, token);
+        if (!isExist) {
+            fcmTokenRepository.save(FcmToken.builder()
+                    .member(member)
+                    .token(token)
+                    .build());
+        }
+
     }
 }

--- a/src/main/java/com/meetkey/server/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/meetkey/server/domain/notification/controller/NotificationController.java
@@ -1,0 +1,42 @@
+package com.meetkey.server.domain.notification.controller;
+
+import com.meetkey.server.domain.notification.service.NotificationService;
+import com.meetkey.server.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "알림 읽음 처리 API", description = "특정 알림을 읽음 처리합니다. (매칭/시스템 알림용)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "MEMBER4041: 해당 사용자를 찾을 수 없습니다. , " +
+                    "NOTIFICATION4041: 해당 알림을 찾을 수 없습니다. , " +
+                    "NOTIFICATION4031: 해당 사용자의 알림이 아닙니다.")
+    })
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Void> readNotification(
+            @Parameter(description = "알림 ID", example = "1") @PathVariable Long notificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        notificationService.readNotification(notificationId, userDetails.getMemberId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/notification/entity/PersonalNotification.java
+++ b/src/main/java/com/meetkey/server/domain/notification/entity/PersonalNotification.java
@@ -44,4 +44,15 @@ public class PersonalNotification extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private ChatMessage chatMessage;
 
+    public void renewNotification(String newContent, ChatMessage newChatMessage) {
+        this.content = newContent;
+        this.chatMessage = newChatMessage;
+        this.isRead = false;
+    }
+
+    public void isRead(boolean isRead) {
+        this.isRead = isRead;
+    }
+
 }
+

--- a/src/main/java/com/meetkey/server/domain/notification/entity/PersonalNotification.java
+++ b/src/main/java/com/meetkey/server/domain/notification/entity/PersonalNotification.java
@@ -18,7 +18,7 @@ public class PersonalNotification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 100)
     private String title;
 
     @Column(nullable = false)

--- a/src/main/java/com/meetkey/server/domain/notification/entity/PersonalNotification.java
+++ b/src/main/java/com/meetkey/server/domain/notification/entity/PersonalNotification.java
@@ -50,8 +50,12 @@ public class PersonalNotification extends BaseEntity {
         this.isRead = false;
     }
 
-    public void isRead(boolean isRead) {
-        this.isRead = isRead;
+    public boolean isRead() {
+        return isRead;
+    }
+
+    public void read() {
+        this.isRead = true;
     }
 
 }

--- a/src/main/java/com/meetkey/server/domain/notification/exception/NotificationErrorStatus.java
+++ b/src/main/java/com/meetkey/server/domain/notification/exception/NotificationErrorStatus.java
@@ -1,0 +1,20 @@
+package com.meetkey.server.domain.notification.exception;
+
+import com.meetkey.server.global.apiPayload.code.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorStatus implements BaseCode {
+    // 400 Bad Request
+    NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION4031", "해당 알림에 대한 권한이 없습니다.."),
+
+    // 404 Not Found
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4041", "존재하지 않는 알림입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/meetkey/server/domain/notification/exception/NotificationException.java
+++ b/src/main/java/com/meetkey/server/domain/notification/exception/NotificationException.java
@@ -1,0 +1,9 @@
+package com.meetkey.server.domain.notification.exception;
+
+import com.meetkey.server.global.apiPayload.exception.GeneralException;
+
+public class NotificationException extends GeneralException {
+    public NotificationException(NotificationErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/meetkey/server/domain/notification/repository/FcmTokenRepository.java
@@ -1,0 +1,14 @@
+package com.meetkey.server.domain.notification.repository;
+
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.entity.mapping.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    List<FcmToken> findAllByMember(Member member);
+
+    boolean existsByMemberAndToken(Member member, String fcmToken);
+}

--- a/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface NotificationRepository extends JpaRepository<PersonalNotification, Long> {
+public interface NotificationRepository extends JpaRepository<PersonalNotification, Long>, NotificationRepositoryCustom {
 
     // 특정 송신자 -> 수신자에게 특정 타입의 읽지 않은 알림이 있는지 조회
     Optional<PersonalNotification> findTopByReceiverAndSenderAndTypeAndIsReadFalse(
@@ -15,4 +15,8 @@ public interface NotificationRepository extends JpaRepository<PersonalNotificati
             Member sender,
             NotificationType type
     );
+
+
+
+
 }

--- a/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,18 @@
+package com.meetkey.server.domain.notification.repository;
+
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.notification.entity.PersonalNotification;
+import com.meetkey.server.domain.notification.enums.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<PersonalNotification, Long> {
+
+    // 특정 송신자 -> 수신자에게 특정 타입의 읽지 않은 알림이 있는지 조회
+    Optional<PersonalNotification> findTopByReceiverAndSenderAndTypeAndIsReadFalse(
+            Member receiver,
+            Member sender,
+            NotificationType type
+    );
+}

--- a/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.meetkey.server.domain.notification.repository;
+
+import com.meetkey.server.domain.member.entity.Member;
+
+import java.util.Optional;
+
+public interface NotificationRepositoryCustom {
+    void markAsReadBySender(Member receiver, Member sender);
+
+}

--- a/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/meetkey/server/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.meetkey.server.domain.notification.repository;
+
+import com.meetkey.server.domain.member.entity.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.meetkey.server.domain.chat.entity.QChatRoomMember.chatRoomMember;
+import static com.meetkey.server.domain.member.entity.QMember.member;
+import static com.meetkey.server.domain.notification.entity.QPersonalNotification.personalNotification;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    @Override
+    public void markAsReadBySender(Member receiver, Member sender) {
+        long count = queryFactory
+                .update(personalNotification)
+                .set(personalNotification.isRead, true) // true로 변경
+                .where(
+                        personalNotification.receiver.eq(receiver),
+                        personalNotification.sender.eq(sender),
+                        personalNotification.isRead.isFalse()
+
+                )
+                .execute();
+
+        em.flush();
+        em.clear();
+    }
+
+}

--- a/src/main/java/com/meetkey/server/domain/notification/service/FcmService.java
+++ b/src/main/java/com/meetkey/server/domain/notification/service/FcmService.java
@@ -1,0 +1,54 @@
+package com.meetkey.server.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.entity.mapping.FcmToken;
+import com.meetkey.server.domain.notification.repository.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FcmService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Async
+    public void sendPush(Member receiver, String title, String body) {
+
+        // 받는 사람의 토큰 조회
+        List<FcmToken> tokens = fcmTokenRepository.findAllByMember(receiver);
+
+        if (tokens.isEmpty()) {
+            log.info("FCM 토큰이 없어 알림을 건너뜁니다. memberId: {}", receiver.getId());
+            return;
+        }
+
+        // 토큰 별로 전송
+        for (FcmToken fcmToken : tokens) {
+            try {
+                Notification notification = Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build();
+
+                Message message = Message.builder()
+                        .setToken(fcmToken.getToken())
+                        .setNotification(notification)
+                        .build();
+
+                FirebaseMessaging.getInstance().send(message);
+                log.info("FCM 전송 성공: memberId={}, token={}", receiver.getId(), fcmToken.getToken());
+            } catch (Exception e) {
+                log.error("FCM 전송 실패: token={}", fcmToken.getToken(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/meetkey/server/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/meetkey/server/domain/notification/service/NotificationService.java
@@ -2,8 +2,13 @@ package com.meetkey.server.domain.notification.service;
 
 import com.meetkey.server.domain.chat.entity.ChatMessage;
 import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.exception.MemberErrorStatus;
+import com.meetkey.server.domain.member.exception.MemberException;
+import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.domain.notification.entity.PersonalNotification;
 import com.meetkey.server.domain.notification.enums.NotificationType;
+import com.meetkey.server.domain.notification.exception.NotificationErrorStatus;
+import com.meetkey.server.domain.notification.exception.NotificationException;
 import com.meetkey.server.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +25,7 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final FcmService fcmService;
+    private final MemberRepository memberRepository;
 
     // 알림 전송 및 저장
     public void sendNotification(Member sender, Member receiver, NotificationType type, String messageContent, ChatMessage chatMessage) {
@@ -33,6 +39,30 @@ public class NotificationService {
             createNotification(sender, receiver, type, title, messageContent, chatMessage);
         }
 
+    }
+
+    // 알림 하나를 클릭했을 때
+    public void readNotification(Long notificationId, Long receiverId) {
+        Member receiver = memberRepository.findById(receiverId).orElseThrow(
+                () -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        PersonalNotification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        // 내 알림이 맞는지 확인
+        if (!notification.getReceiver().getId().equals(receiver.getId())) {
+            throw new NotificationException(NotificationErrorStatus.NOTIFICATION_FORBIDDEN);
+        }
+
+        if (notification.isRead()) {
+            return;
+        }
+
+        notification.read();
+    }
+
+    public void readNotificationBySender(Member receiver, Member sender) {
+        notificationRepository.markAsReadBySender(receiver, sender);
     }
 
     private void handleMessageNotification(Member sender, Member receiver, NotificationType type, String title, String content, ChatMessage chatMessage) {
@@ -49,6 +79,7 @@ public class NotificationService {
             createNotification(sender, receiver, type, title, content, chatMessage);
         }
     }
+
 
     private void createNotification(Member sender, Member receiver, NotificationType type, String title, String content, ChatMessage chatMessage) {
         PersonalNotification notification = PersonalNotification.builder()

--- a/src/main/java/com/meetkey/server/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/meetkey/server/domain/notification/service/NotificationService.java
@@ -1,10 +1,18 @@
 package com.meetkey.server.domain.notification.service;
 
+import com.meetkey.server.domain.chat.entity.ChatMessage;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.notification.entity.PersonalNotification;
+import com.meetkey.server.domain.notification.enums.NotificationType;
 import com.meetkey.server.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
 @Transactional
@@ -12,4 +20,62 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final FcmService fcmService;
+
+    // 알림 전송 및 저장
+    public void sendNotification(Member sender, Member receiver, NotificationType type, String messageContent, ChatMessage chatMessage) {
+
+        String title = makeTitle(sender, type);
+
+        if (type == NotificationType.MESSAGE) {
+            handleMessageNotification(sender, receiver, type, title, messageContent, chatMessage);
+        } else {
+            // 메시지 외의 알림은 무조건 새로 생성
+            createNotification(sender, receiver, type, title, messageContent, chatMessage);
+        }
+
+    }
+
+    private void handleMessageNotification(Member sender, Member receiver, NotificationType type, String title, String content, ChatMessage chatMessage) {
+        // 이 사람이 보낸 '안 읽은' 메시지 알림이 이미 있는지 확인
+        Optional<PersonalNotification> existingNoti = notificationRepository
+                .findTopByReceiverAndSenderAndTypeAndIsReadFalse(receiver, sender, type);
+
+        if (existingNoti.isPresent()) {
+            // 안 읽은 게 있다 -> 기존 알림 내용만 갱신 (Update 쿼리 나감)
+            existingNoti.get().renewNotification(content, chatMessage);
+            log.info("기존 알림 갱신 완료: notificationId={}", existingNoti.get().getId());
+        } else {
+            // 다 읽었거나 없음 -> 새로 생성 (Insert 쿼리 나감)
+            createNotification(sender, receiver, type, title, content, chatMessage);
+        }
+    }
+
+    private void createNotification(Member sender, Member receiver, NotificationType type, String title, String content, ChatMessage chatMessage) {
+        PersonalNotification notification = PersonalNotification.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .type(type)
+                .title(title)
+                .content(content)
+                .isRead(false) // 기본값 안 읽음
+                .chatMessage(chatMessage) // 채팅 메시지 연결 (null일 수도 있음)
+                .build();
+
+        notificationRepository.save(notification);
+        log.info("새 알림 저장 완료: receiverId={}, type={}", receiver.getId(), type);
+    }
+
+
+    private String makeTitle(Member sender, NotificationType type) {
+        return switch (type) {
+            case MESSAGE -> sender.getName(); // 메시지는 보낸 사람 이름이 제목
+            case MATCH -> "✨ 새로운 매칭 성공!";
+            case INCOMING_CALL -> "📞 전화 요청이 왔습니다.";
+            case MISSED_CALL -> "❌ 부재중 전화 알림";
+            default -> "알림";
+        };
+    }
+
+
+
 }

--- a/src/main/java/com/meetkey/server/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/meetkey/server/domain/notification/service/NotificationService.java
@@ -1,0 +1,15 @@
+package com.meetkey.server.domain.notification.service;
+
+import com.meetkey.server.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final FcmService fcmService;
+}

--- a/src/main/java/com/meetkey/server/global/config/FcmConfig.java
+++ b/src/main/java/com/meetkey/server/global/config/FcmConfig.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 @Configuration
 public class FcmConfig {
 
-    @Value("${fcm.key-path}")
+    @Value("${fcm.key.path}")
     private String fcmKeyPath;
 
     @PostConstruct

--- a/src/main/java/com/meetkey/server/global/config/FcmConfig.java
+++ b/src/main/java/com/meetkey/server/global/config/FcmConfig.java
@@ -1,0 +1,34 @@
+package com.meetkey.server.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.key-path}")
+    private String fcmKeyPath;
+
+    @PostConstruct
+    public void init() {
+        try {
+            InputStream serviceAccount = new ClassPathResource(fcmKeyPath).getInputStream();
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("FCM 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -44,3 +44,7 @@ cloud:
     credentials:
       access-key: ${AWS_ACCESS_KEY:}
       secret-key: ${AWS_SECRET_KEY:}
+
+fcm:
+  key:
+    path: ${FCM_PATH:}


### PR DESCRIPTION
## 요약
1. Fcm 토큰 생성
2. 알림 생성
3. 알림 읽음 처리
4. 채팅방 알림 설정/해제 토글

## 연결된 이슈 번호
- close #46 


## 세부 작업 사항
- ChatRoomMember 엔티티에 isAlarm 필드 추가 -> 채팅방 알림 설정/해제 토글
- 접속 시 또는 로그인시에 FCM 토큰 발급
- 채팅시에 상대방에게 알림 전송(제목 : sender 이름, 내용 : 메시지 내용)
- 채팅방에 들어가면 해당 채팅방에 대한 알림은 읽음 처리가됨
- 알림 읽음 처리 API는 매칭, 공통 알림 같은 단일 알림에 대한 읽음 처리

## Approve 하기 전에 확인할 것
## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
