### PR TITLE
feat: 매칭 알고리즘 업데이트(채팅 로직 반영)

### DIFF
--- a/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/meetkey/server/domain/chat/repository/ChatRoomMemberRepository.java
@@ -6,6 +6,7 @@ import com.meetkey.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,5 +45,14 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
         where crm.chatRoom.id = :chatRoomId
     """)
     List<Long> findMemberIdsByChatRoomId(Long chatRoomId);
+
+    @Query("""
+        select crm2.member.id
+        from ChatRoomMember crm1
+        join ChatRoomMember crm2 on crm1.chatRoom = crm2.chatRoom
+        where crm1.member = :member
+        and crm2.member != :member
+    """)
+    List<Long> findChattedMemberIds(Member member);
 
 }

--- a/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
+++ b/src/main/java/com/meetkey/server/domain/match/service/MatchServiceImpl.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.domain.match.service;
 
+import com.meetkey.server.domain.chat.repository.ChatRoomMemberRepository;
 import com.meetkey.server.domain.match.dto.*;
 import com.meetkey.server.domain.match.entity.RecommendationQueue;
 import com.meetkey.server.domain.match.enums.MatchType;
@@ -41,6 +42,7 @@ public class MatchServiceImpl implements MatchService {
     private final MemberRepository memberRepository;
     private final PreferenceRepository preferenceRepository;
     private final RecommendationQueueRepository recommendationQueueRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     @Transactional
     @Override
@@ -62,16 +64,34 @@ public class MatchServiceImpl implements MatchService {
         }
 
         // 2. 분기 처리: 일일 할당량 남음 vs 소진 (Recycle)
+        boolean forceRecycle = false;
         if (remainingQuota > 0) {
             // A. Daily Match Mode (새로울 후보 생성)
             // 할당량(remainingQuota)만큼만 생성
             List<RecommendationResDTO> newRecommendations = generateRecommendations(member, request, remainingQuota);
-            return buildResponse(newRecommendations, newRecommendations.size(), MatchType.DAILY_MATCH);
 
-        } else {
-            // B. Recycle Mode (할당량 소진 시)
+            if (!newRecommendations.isEmpty()) {
+                return buildResponse(newRecommendations, newRecommendations.size(), newRecommendations.size(), MatchType.DAILY_MATCH);
+            }
+
+            // 추천된 후보가 없을 때, 프리미엄 유저는 Recycle 모드로 전환
+            if (member.getMembership() == Membership.PREMIUM) {
+                forceRecycle = true;
+            } else {
+                return buildResponse(Collections.emptyList(), 0, 0, MatchType.DAILY_MATCH);
+            }
+        }
+
+        if (remainingQuota <= 0 || forceRecycle) {
+            // B. Recycle Mode (할당량 소진 시 또는 프리미엄 유저 후보 없음)
             // 재활용 대상: DISLIKE 했거나, LIKE 했지만 채팅 시작 안 한 유저
             List<Member> recycleMembers = memberLikeRepository.findRecycleMembers(member);
+
+            // 채팅방이 존재하는 유저 제외
+            List<Long> chattedMemberIds = chatRoomMemberRepository.findChattedMemberIds(member);
+            recycleMembers = recycleMembers.stream()
+                .filter(m -> !chattedMemberIds.contains(m.getId()))
+                .collect(Collectors.toList());
 
             // 랜덤으로 섞어서 반환 (또는 최신순 등)
             Collections.shuffle(recycleMembers);
@@ -96,16 +116,25 @@ public class MatchServiceImpl implements MatchService {
                 })
                 .collect(Collectors.toList());
 
-            return buildResponse(dtos, dtos.size(), MatchType.RECYCLE);
+            MatchType type = MatchType.RECYCLE;
+            int remaining = 0;
+            if (member.getMembership() == Membership.PREMIUM) {
+                type = MatchType.DAILY_MATCH;
+                remaining = 10;
+            }
+
+            return buildResponse(dtos, remaining, dtos.size(), type);
         }
+
+        return buildResponse(Collections.emptyList(), 0, 0, MatchType.DAILY_MATCH);
     }
 
-    private MatchListResDTO buildResponse(List<RecommendationResDTO> list, int remaining, MatchType type) {
+    private MatchListResDTO buildResponse(List<RecommendationResDTO> list, int remaining, int total, MatchType type) {
         return MatchListResDTO.builder()
             .recommendations(list)
             .swipeInfo(MatchListResDTO.SwipeInfoDTO.builder()
                 .remainingCount(remaining)
-                .totalCount(10)
+                .totalCount(total)
                 .build())
             .matchType(type)
             .build();
@@ -114,6 +143,8 @@ public class MatchServiceImpl implements MatchService {
     private List<RecommendationResDTO> generateRecommendations(Member member, RecommendationReqDTO request, int limit) {
         // 1. 기 스와이프 유저 제외
         List<Long> excludedIds = memberLikeRepository.findSwipedMemberIdsByMember(member);
+        // 1.1 이미 채팅한 유저 제외
+        excludedIds.addAll(chatRoomMemberRepository.findChattedMemberIds(member));
 
         // 1.5. 위치 정보 보정 (요청에 좌표 없고 DB에 있으면 DB 값 사용)
         MemberLocation myLocation = memberLocationRepository.findByMember(member).orElse(null);


### PR DESCRIPTION
## 요약
- 매칭 알고리즘에서 제외되어 있었던 채팅 개설 여부 항목 추가


<br>

## 연결된 이슈 번호
- close #49 

<br>
<br>

## 세부 작업 사항
- 채팅이 개설될 시, 무료 사용자의 하루 추천 개수 차감
- 매칭 상대로 채팅을 주고받은 상대는 제외
<br>
<br>

<br>
<br>

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
