### PR TITLE
[FIX] 사용자 차단 로직 구현 및 신고 시 차단하도록 로직 수정

### DIFF
--- a/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
@@ -1,7 +1,14 @@
 package com.meetkey.server.domain.member.controller;
 
 import com.meetkey.server.domain.member.dto.MemberReqDTO;
+import com.meetkey.server.domain.member.dto.MemberResDTO;
 import com.meetkey.server.domain.member.dto.ProfileResDTO;
+import com.meetkey.server.domain.member.entity.Member;
+import com.meetkey.server.domain.member.entity.mapping.MemberBlock;
+import com.meetkey.server.domain.member.exception.MemberErrorStatus;
+import com.meetkey.server.domain.member.exception.MemberException;
+import com.meetkey.server.domain.member.repository.MemberBlockRepository;
+import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.domain.member.service.MemberService;
 import com.meetkey.server.global.apiPayload.response.BasicResponse;
 import com.meetkey.server.global.apiPayload.status.CommonSuccessStatus;
@@ -14,10 +21,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.meetkey.server.domain.member.dto.MemberReqDTO.*;
 
@@ -27,6 +33,8 @@ import static com.meetkey.server.domain.member.dto.MemberReqDTO.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
+    private final MemberBlockRepository memberBlockRepository;
 
     @Operation(summary = "FCM 토큰 저장 API", description = "사용자의 FCM 토큰을 저장합니다. (앱이 켜지거나 로그인시에 호출)")
     @ApiResponses(value = {
@@ -40,5 +48,14 @@ public class MemberController {
     ) {
         memberService.saveFcmToken(userDetails.getMemberId(), request.token());
         return ResponseEntity.ok(BasicResponse.success(CommonSuccessStatus._OK, "토큰 저장 완료"));
+    }
+
+    @PostMapping("/block/{memberId}")
+    public ResponseEntity<BasicResponse<MemberResDTO.Block>> blockMember(
+            @AuthenticationPrincipal CustomUserDetails fromMember,
+            @PathVariable("memberId") Long toMemberId
+    ){
+        MemberResDTO.Block res = memberService.blockMember(fromMember.getMemberId(), toMemberId);
+        return ResponseEntity.ok(BasicResponse.success(CommonSuccessStatus._OK, res));
     }
 }

--- a/src/main/java/com/meetkey/server/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/meetkey/server/domain/member/dto/MemberResDTO.java
@@ -1,0 +1,13 @@
+package com.meetkey.server.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+public class MemberResDTO {
+
+    @Builder
+    public record Block(
+            @NotNull Long fromMemberId,
+            @NotNull Long toMemberId
+    ){}
+}

--- a/src/main/java/com/meetkey/server/domain/member/entity/mapping/FromToId.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/mapping/FromToId.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
 public class FromToId {

--- a/src/main/java/com/meetkey/server/domain/member/entity/mapping/MemberBlock.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/mapping/MemberBlock.java
@@ -3,15 +3,13 @@ package com.meetkey.server.domain.member.entity.mapping;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Table(name = "member_block")
 public class MemberBlock extends BaseEntity {
     @EmbeddedId

--- a/src/main/java/com/meetkey/server/domain/member/exception/MemberErrorStatus.java
+++ b/src/main/java/com/meetkey/server/domain/member/exception/MemberErrorStatus.java
@@ -17,7 +17,8 @@ public enum MemberErrorStatus implements BaseCode {
 
     // 회원 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4041", "해당 사용자를 찾을 수 없습니다."),
-    INVALID_S3_KEY(HttpStatus.NOT_FOUND, "MEMBER4042", "저장된 프로필 사진을 찾을 수 없습니다.");
+    INVALID_S3_KEY(HttpStatus.NOT_FOUND, "MEMBER4042", "저장된 프로필 사진을 찾을 수 없습니다."),
+    ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "MEMBER_4001", "이미 차단된 사용자입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetkey/server/domain/member/repository/MemberBlockRepository.java
+++ b/src/main/java/com/meetkey/server/domain/member/repository/MemberBlockRepository.java
@@ -1,0 +1,20 @@
+package com.meetkey.server.domain.member.repository;
+
+import com.meetkey.server.domain.member.entity.mapping.FromToId;
+import com.meetkey.server.domain.member.entity.mapping.MemberBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberBlockRepository extends JpaRepository<MemberBlock, FromToId> {
+    // fromId가 toId를 차단했는지를 알 수 있는 메소드
+    // ex) existsByMemberBlockIdFromIdAndMemberBlockIdToId(myId, targetId)
+    boolean existsByMemberBlockIdFromIdAndMemberBlockIdToId(Long fromId, Long toId);
+
+    // 내가 누구를 차단했는지
+    // ex)  List<MemberBlock> l = memberBlockRepository.findAllByMemberBlockIdFromId(1L);
+    // for (MemberBlock mb : l){
+    //            System.out.println(mb.getToMember().getId());
+    // }
+    List<MemberBlock> findAllByMemberBlockIdFromId(Long fromId);
+}

--- a/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
@@ -2,13 +2,17 @@ package com.meetkey.server.domain.member.service;
 
 
 import com.meetkey.server.domain.member.dto.MemberReqDTO;
+import com.meetkey.server.domain.member.dto.MemberResDTO;
 import com.meetkey.server.domain.member.entity.Member;
 import com.meetkey.server.domain.member.entity.SocialLogin;
 import com.meetkey.server.domain.member.entity.mapping.FcmToken;
+import com.meetkey.server.domain.member.entity.mapping.FromToId;
+import com.meetkey.server.domain.member.entity.mapping.MemberBlock;
 import com.meetkey.server.domain.member.enums.Provider;
 import com.meetkey.server.domain.member.enums.Role;
 import com.meetkey.server.domain.member.exception.MemberErrorStatus;
 import com.meetkey.server.domain.member.exception.MemberException;
+import com.meetkey.server.domain.member.repository.MemberBlockRepository;
 import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.domain.member.repository.SocialLoginRepository;
 import com.meetkey.server.domain.notification.repository.FcmTokenRepository;
@@ -22,6 +26,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final SocialLoginRepository socialLoginRepository;
     private final FcmTokenRepository fcmTokenRepository;
+    private final MemberBlockRepository memberBlockRepository;
 
     @Transactional
     public Member signup(Provider provider, String providerId, MemberReqDTO.Signup req) {
@@ -72,6 +77,33 @@ public class MemberService {
         socialLoginRepository.save(socialMember);
 
         return member;
+    }
+    @Transactional
+    public MemberResDTO.Block blockMember(Long fromId, Long toId){
+        // 멤버 있는지 없는지 확인
+        Member fromMember = memberRepository.findById(fromId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+        Member toMember = memberRepository.findById(toId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+        FromToId blockId = new FromToId(fromId, toId);
+
+        // 중복 차단인지 확인
+        if (memberBlockRepository.existsById(blockId)) {
+            throw new MemberException(MemberErrorStatus.ALREADY_BLOCKED);
+        }
+
+        MemberBlock memberBlock = MemberBlock.builder()
+                .memberBlockId(blockId)
+                .fromMember(fromMember)
+                .toMember(toMember)
+                .build();
+
+        memberBlockRepository.save(memberBlock);
+
+        return MemberResDTO.Block.builder()
+                .fromMemberId(fromId)
+                .toMemberId(toId)
+                .build();
     }
 
     // FCM 토큰 저장

--- a/src/main/java/com/meetkey/server/domain/report/controller/ReportController.java
+++ b/src/main/java/com/meetkey/server/domain/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.meetkey.server.domain.report.controller;
 
+import com.meetkey.server.domain.member.service.MemberService;
 import com.meetkey.server.domain.report.dto.ReportReqDTO;
 import com.meetkey.server.domain.report.service.ReportService;
 import com.meetkey.server.global.apiPayload.response.BasicResponse;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/report")
 public class ReportController {
     private final ReportService reportService;
+    private final MemberService memberService;
 
     @PostMapping("/{targetId}")
     public ResponseEntity<BasicResponse<Void>> createReport(
@@ -23,6 +25,8 @@ public class ReportController {
             @RequestBody ReportReqDTO.CreateReport req
     ) {
         reportService.createReport(reporter.getMemberId(), targetId, req);
+        memberService.blockMember(reporter.getMemberId(), targetId);
+
         return ResponseEntity.ok()
                 .body(BasicResponse.success(CommonSuccessStatus._OK, null));
     }


### PR DESCRIPTION
## 요약
- 스크린샷 첨부
<img width="384" height="190" alt="image" src="https://github.com/user-attachments/assets/d9af5bc0-4436-4efa-8bce-9c4ea9bbbfc3" />

<br>
<br>

## 연결된 이슈 번호
- close #55 

<br>
<br>

## 세부 작업 사항
- 현재 사용자가 차단한 사용자를 리스트로 불러오는 메소드, A가 B를 차단했는지 여부를 판단하는 메소드를 `MemberBlockRepository`에 추가하였습니다.
- 신고하기 기능을 할 시에 차단을 바로 하도록 수정하였습니다. 
<br>
<br>



## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
