### PR TITLE
[FIX] 멤버십 / 프로필 사진 연결

### DIFF
--- a/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meetkey/server/domain/member/controller/MemberController.java
@@ -1,12 +1,6 @@
 package com.meetkey.server.domain.member.controller;
 
-import com.meetkey.server.domain.member.dto.MemberReqDTO;
 import com.meetkey.server.domain.member.dto.MemberResDTO;
-import com.meetkey.server.domain.member.dto.ProfileResDTO;
-import com.meetkey.server.domain.member.entity.Member;
-import com.meetkey.server.domain.member.entity.mapping.MemberBlock;
-import com.meetkey.server.domain.member.exception.MemberErrorStatus;
-import com.meetkey.server.domain.member.exception.MemberException;
 import com.meetkey.server.domain.member.repository.MemberBlockRepository;
 import com.meetkey.server.domain.member.repository.MemberRepository;
 import com.meetkey.server.domain.member.service.MemberService;
@@ -22,8 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static com.meetkey.server.domain.member.dto.MemberReqDTO.*;
 
@@ -57,5 +49,13 @@ public class MemberController {
     ){
         MemberResDTO.Block res = memberService.blockMember(fromMember.getMemberId(), toMemberId);
         return ResponseEntity.ok(BasicResponse.success(CommonSuccessStatus._OK, res));
+    }
+
+    @PatchMapping("/membership")
+    public ResponseEntity<BasicResponse<Void>> updateMembershipStatus(
+            @AuthenticationPrincipal CustomUserDetails details
+    ){
+        memberService.updateMembershipStatus(details.getMemberId());
+        return ResponseEntity.ok(BasicResponse.success(CommonSuccessStatus._OK, null));
     }
 }

--- a/src/main/java/com/meetkey/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/meetkey/server/domain/member/controller/ProfileController.java
@@ -226,7 +226,7 @@ public class ProfileController {
         return BasicResponse.success(CommonSuccessStatus._OK, null);
     }
 
-    @Operation(summary = "내 프로필 사진 조회 API", description = "로그인한 사용자의 프로필 사진 URL 리스트를 가져옵니다.")
+    @Operation(summary = "내 프로필 사진 조회 API", description = "로그인한 사용자의 모든 프로필 사진 URL 리스트를 가져옵니다.")
     @GetMapping("/photos")
     public BasicResponse<List<String>> getMyPhotos(
             @AuthenticationPrincipal CustomUserDetails customUserDetails

--- a/src/main/java/com/meetkey/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/meetkey/server/domain/member/controller/ProfileController.java
@@ -214,6 +214,7 @@ public class ProfileController {
         return BasicResponse.success(CommonSuccessStatus._OK, responses);
     }
 
+    @Operation(summary = "프로필 key 저장 API", description = "앞선 요청으로 받은 프로필 key들을 DB에 저장합니다. ")
     @PostMapping("/photos/register")
     public BasicResponse<Void> registerMemberPhotos(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -226,7 +227,7 @@ public class ProfileController {
         return BasicResponse.success(CommonSuccessStatus._OK, null);
     }
 
-    @Operation(summary = "내 프로필 사진 조회 API", description = "로그인한 사용자의 모든 프로필 사진 URL 리스트를 가져옵니다.")
+    @Operation(summary = "내 프로필 사진 전체 조회 API", description = "로그인한 사용자의 모든 프로필 사진 URL 리스트를 가져옵니다.")
     @GetMapping("/photos")
     public BasicResponse<List<String>> getMyPhotos(
             @AuthenticationPrincipal CustomUserDetails customUserDetails

--- a/src/main/java/com/meetkey/server/domain/member/converter/ProfileConverter.java
+++ b/src/main/java/com/meetkey/server/domain/member/converter/ProfileConverter.java
@@ -123,7 +123,8 @@ public class ProfileConverter {
             Member member,
             List<Interest> interests,
             Preference personality,
-            BadgeResponse badge
+            BadgeResponse badge,
+            String profileUrl
     ) {
         List<String> interestNames = interests.stream()
                 .map(interest -> interest.getType().name())
@@ -135,7 +136,7 @@ public class ProfileConverter {
                 .first(member.getFirstLanguage())
                 .target(member.getTargetLanguage())
                 .age(member.getAge())
-                .profileImage("image")
+                .profileImage(profileUrl)
                 .recommendCount(member.getRecommendCount())
                 .notRecommendCount(member.getNotRecommendCount())
                 .badge(badge)
@@ -151,7 +152,8 @@ public class ProfileConverter {
             List<Interest> interests,
             Preference personality,
             String distance,
-            BadgeResponse badge
+            BadgeResponse badge,
+            String profileUrl
     ) {
         List<String> interestNames = interests.stream()
                 .map(interest -> interest.getType().name())
@@ -163,7 +165,7 @@ public class ProfileConverter {
                 .age(member.getAge())
                 .gender(member.getGender())
                 .homeTown(member.getHomeTown())
-                .profileImage("image")
+                .profileImage(profileUrl)
                 .location(member.getLocation())
                 .distance(distance)
                 .recommendCount(member.getRecommendCount())

--- a/src/main/java/com/meetkey/server/domain/member/entity/Member.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.meetkey.server.domain.member.entity;
 
 import com.meetkey.server.domain.member.entity.mapping.InterestMember;
+import com.meetkey.server.domain.member.entity.mapping.MemberPhoto;
 import com.meetkey.server.domain.member.enums.*;
 import com.meetkey.server.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -97,6 +98,10 @@ public class Member extends BaseEntity {
     public int getAge() {
         if (this.birthday == null) return 0;
         return LocalDate.now().getYear() - this.birthday.getYear() + 1;
+    }
+
+    public void updateProfilePhotoUrl(String profilePhotoUrl) {
+        this.profileImageUrl = profilePhotoUrl;
     }
 
     public void updateMemberShip() {

--- a/src/main/java/com/meetkey/server/domain/member/entity/Member.java
+++ b/src/main/java/com/meetkey/server/domain/member/entity/Member.java
@@ -99,6 +99,15 @@ public class Member extends BaseEntity {
         return LocalDate.now().getYear() - this.birthday.getYear() + 1;
     }
 
+    public void updateMemberShip() {
+        if (this.membership == Membership.FREE) {
+            this.membership = Membership.PREMIUM;
+        }
+        else {
+            this.membership = Membership.FREE;
+        }
+    }
+
     public void increaseRecommend() {
         this.recommendCount++;
     }

--- a/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/MemberService.java
@@ -78,13 +78,12 @@ public class MemberService {
 
         return member;
     }
+
     @Transactional
     public MemberResDTO.Block blockMember(Long fromId, Long toId){
         // 멤버 있는지 없는지 확인
-        Member fromMember = memberRepository.findById(fromId)
-                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
-        Member toMember = memberRepository.findById(toId)
-                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+        Member fromMember = findMemberById(fromId);
+        Member toMember = findMemberById(toId);
         FromToId blockId = new FromToId(fromId, toId);
 
         // 중복 차단인지 확인
@@ -106,6 +105,13 @@ public class MemberService {
                 .build();
     }
 
+    @Transactional
+    public void updateMembershipStatus(Long memberId){
+        Member member = findMemberById(memberId);
+
+        member.updateMemberShip();
+    }
+
     // FCM 토큰 저장
     @Transactional
     public void saveFcmToken(Long memberId, String token) {
@@ -119,6 +125,10 @@ public class MemberService {
                     .token(token)
                     .build());
         }
+    }
 
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/meetkey/server/domain/member/service/ProfileService.java
+++ b/src/main/java/com/meetkey/server/domain/member/service/ProfileService.java
@@ -13,6 +13,7 @@ import com.meetkey.server.domain.member.enums.InterestType;
 import com.meetkey.server.domain.member.exception.MemberErrorStatus;
 import com.meetkey.server.domain.member.exception.MemberException;
 import com.meetkey.server.domain.member.repository.*;
+import com.meetkey.server.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,7 @@ public class ProfileService {
     private final EvaluationRepository evaluationRepository;
     private final BadgeService badgeService;
     private final GeocodingService geocodingService;
+    private final S3Service s3Service;
 
     public ProfileUpdateResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
         Member member = getMember(memberId);
@@ -161,7 +163,9 @@ public class ProfileService {
             .map(InterestMember::getInterest)
             .toList();
 
-        return profileConverter.toProfileResponse(member, interests, preference, badge);
+        String profileImageUrl = s3Service.generateGetPresignedUrl(member.getProfileImageUrl());
+
+        return profileConverter.toProfileResponse(member, interests, preference, badge, profileImageUrl);
     }
 
     // 다른 사람 프로필 조회
@@ -185,7 +189,9 @@ public class ProfileService {
             .map(InterestMember::getInterest)
             .toList();
 
-        return profileConverter.toOtherProfileResponse(target, interests, preference, distance, badge);
+        String profileImageUrl = s3Service.generateGetPresignedUrl(target.getProfileImageUrl());
+
+        return profileConverter.toOtherProfileResponse(target, interests, preference, distance, badge, profileImageUrl);
     }
 
 

--- a/src/main/java/com/meetkey/server/global/s3/S3Service.java
+++ b/src/main/java/com/meetkey/server/global/s3/S3Service.java
@@ -109,6 +109,10 @@ public class S3Service {
                 .collect(Collectors.toList());
 
         memberPhotoRepository.saveAll(photos);
+
+        if (!s3Keys.isEmpty()) {
+            member.updateProfilePhotoUrl(s3Keys.get(0));
+        }
     }
 
 


### PR DESCRIPTION
## 요약
- 스크린샷 첨부
<img width="1175" height="373" alt="image" src="https://github.com/user-attachments/assets/9d2f9cad-6d2a-49eb-a2c0-d13fe010658f" />


<br>
<br>

## 연결된 이슈 번호
- close #58 

<br>
<br>

## 세부 작업 사항
- 멤버십은 `/users/membership` 으로 요청보내면 유료 <-> 무료 바뀌도록 수정했습니다.
- 사용자가 프로필을 새로 저장하면, 처음 사진을 대표 사진으로 선택하고 member 도메인 url에 해당 s3 key를 저장하도록 하였습니다.
- 이후 getProfileInfo 를 할 때에 s3 url로 변경하여 converter 에 제대로 된 url 이 담길 수 있도록 연결하였습니다.  
<br>
<br>



## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!