### PR TITLE
[FIX] 점수 중복 지급 방지

### DIFF
--- a/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/meetkey/server/domain/badge/service/BadgeService.java
@@ -85,7 +85,7 @@ public class BadgeService {
     public void checkAuthentication(Long memberId) {
         Member member = getMember(memberId);
 
-        if (Boolean.TRUE.equals(member.isVerified())) {
+        if (Boolean.TRUE.equals(member.isVerified()) && !hasAlreadyReceived(member, ReasonType.AUTH)) {
             rewardPoints(member, ReasonType.AUTH);
         }
     }
@@ -100,7 +100,7 @@ public class BadgeService {
                 member.getTargetLanguage() != null &&
                 member.getTargetLanguageLevel() != null;
 
-        if (isComplete) {
+        if (isComplete && !hasAlreadyReceived(member, ReasonType.PROFILE)) {
             rewardPoints(member, ReasonType.PROFILE);
         }
     }
@@ -109,7 +109,7 @@ public class BadgeService {
     public void checkPositiveEvaluation(Long memberId) {
         Member member = getMember(memberId);
 
-        if (member.getRecommendCount() >= 10) {
+        if (member.getRecommendCount() >= 10 && !hasAlreadyReceived(member, ReasonType.PROFILE)) {
             rewardPoints(member, ReasonType.POSITIVE);
         }
     }
@@ -118,6 +118,10 @@ public class BadgeService {
     public void rewardRepeatable(Long memberId, ReasonType reasonType) {
         Member member = getMember(memberId);
         rewardPoints(member, reasonType);
+    }
+
+    private boolean hasAlreadyReceived(Member member, ReasonType reasonType) {
+        return pointHistoryRepository.existsByMemberAndReasonType(member, reasonType);
     }
 
     // 사용자 찾기 메소드

--- a/src/main/java/com/meetkey/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/meetkey/server/domain/member/controller/ProfileController.java
@@ -167,6 +167,7 @@ public class ProfileController {
             @ApiResponse(description = "200", responseCode = "요청 성공", content = @Content(schema = @Schema(implementation = OtherProfileResponse.class))),
             @ApiResponse(responseCode = "400", description = "MEMBER4041: 해당 사용자를 찾을 수 없습니다., MEMBER4031: 차단된 or 차단한 사용자의 프로필은 조회할 수 없습니다.")
     })
+
     @GetMapping("/{targetId}")
     public ResponseEntity<BasicResponse<OtherProfileResponse>> getOtherProfile(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,


### PR DESCRIPTION
## 요약
- 스크린샷 첨부

<br>
<br>

## 연결된 이슈 번호
- close #70 

<br>
<br>

## 세부 작업 사항
- 본인인증, 프로필 작성 완료 시 점수가 중복 지급되던 문제 해결
- 추천10개시 지급되는 포인트는 최초 추천10개 달성 시 주어지며, 추천이 10개 이하로 떨어지더라도 점수는 회수되지 않으며 다시 추천 10개를 달성해도 점수가 지급되지 않음
<br>
<br>

## Approve 하기 전에 확인할 것


<br>
<br>

## 체크리스트
- [x] PR 제목 확인!
- [x] 이슈 연결 확인!
